### PR TITLE
[crud-psr-7-api] cover type checks and tests

### DIFF
--- a/packages/toggle-crud-psr7-api/composer.json
+++ b/packages/toggle-crud-psr7-api/composer.json
@@ -19,7 +19,8 @@
         "pheature/toggle-model": "@dev",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
-        "psr/http-server-handler": "^1.0"
+        "psr/http-server-handler": "^1.0",
+        "webmozart/assert": "^1.10"
     },
     "require-dev": {
         "infection/infection": "^0.21.0",

--- a/packages/toggle-crud-psr7-api/src/DeleteFeature.php
+++ b/packages/toggle-crud-psr7-api/src/DeleteFeature.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Pheature\Crud\Psr7\Toggle;
 
+use InvalidArgumentException;
 use Pheature\Crud\Toggle\Command\RemoveFeature as RemoveFeatureCommand;
 use Pheature\Crud\Toggle\Handler\RemoveFeature;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Webmozart\Assert\Assert;
 
 final class DeleteFeature implements RequestHandlerInterface
 {
@@ -23,11 +25,18 @@ final class DeleteFeature implements RequestHandlerInterface
     }
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $featureId = $request->getAttribute('feature_id');
+
+        try {
+            Assert::string($featureId);
+        } catch (InvalidArgumentException $exception) {
+            return $this->responseFactory->createResponse(404, 'Route Not Found.');
+        }
+
         $this->removeFeature->handle(
-            RemoveFeatureCommand::withId($request->getAttribute('feature_id'))
+            RemoveFeatureCommand::withId($featureId)
         );
 
         return $this->responseFactory->createResponse(204, 'Deleted');
     }
 }
-    

--- a/packages/toggle-crud-psr7-api/src/GetFeature.php
+++ b/packages/toggle-crud-psr7-api/src/GetFeature.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Pheature\Crud\Psr7\Toggle;
 
+use InvalidArgumentException;
 use Pheature\Core\Toggle\Exception\FeatureNotFoundException;
 use Pheature\Core\Toggle\Read\FeatureFinder;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Webmozart\Assert\Assert;
 
 final class GetFeature implements RequestHandlerInterface
 {
@@ -24,9 +26,12 @@ final class GetFeature implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $featureId = $request->getAttribute('feature_id');
+
         try {
-            $feature = $this->featureFinder->get($request->getAttribute('feature_id'));
-        } catch (FeatureNotFoundException $exception) {
+            Assert::string($featureId);
+            $feature = $this->featureFinder->get($featureId);
+        } catch (FeatureNotFoundException | InvalidArgumentException $exception) {
             return $this->responseFactory->createResponse(404, 'Route Not Found.');
         }
 
@@ -39,4 +44,3 @@ final class GetFeature implements RequestHandlerInterface
         return $response;
     }
 }
-    

--- a/packages/toggle-crud-psr7-api/src/GetFeatures.php
+++ b/packages/toggle-crud-psr7-api/src/GetFeatures.php
@@ -34,4 +34,3 @@ final class GetFeatures implements RequestHandlerInterface
         return $response;
     }
 }
-    

--- a/packages/toggle-crud-psr7-api/src/PatchRequest.php
+++ b/packages/toggle-crud-psr7-api/src/PatchRequest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Crud\Psr7\Toggle;
+
+use Pheature\Crud\Toggle\Command\AddStrategy;
+use Pheature\Crud\Toggle\Command\DisableFeature;
+use Pheature\Crud\Toggle\Command\EnableFeature;
+use Pheature\Crud\Toggle\Command\RemoveStrategy;
+use Psr\Http\Message\ServerRequestInterface;
+use Webmozart\Assert\Assert;
+
+final class PatchRequest
+{
+    private const ACTION_ENABLE_FEATURE = 'enable_feature';
+    private const ACTION_DISABLE_FEATURE = 'disable_feature';
+    private const ACTION_ADD_STRATEGY = 'add_strategy';
+    private const ACTION_REMOVE_STRATEGY = 'remove_strategy';
+
+    private string $featureId;
+    private string $action;
+    /** @var array<string|mixed>|null  */
+    private ?array $requestData = null;
+
+    public function __construct(string $featureId, ServerRequestInterface $request)
+    {
+        $body = (array)$request->getParsedBody();
+        $action = $body['action'] ?? null;
+        Assert::string($action);
+
+        $value = $body['value'] ?? null;
+        Assert::nullOrIsArray($value);
+
+        $this->featureId = $featureId;
+        $this->action = $action;
+        $this->requestData = $value;
+    }
+
+    public function addStrategyCommand(): AddStrategy
+    {
+        Assert::notNull($this->requestData);
+        Assert::keyExists($this->requestData, 'strategy_id');
+        Assert::keyExists($this->requestData, 'strategy_type');
+        Assert::string($this->requestData['strategy_id']);
+        Assert::string($this->requestData['strategy_type']);
+
+        return AddStrategy::withIdAndType(
+            $this->featureId,
+            $this->requestData['strategy_id'],
+            $this->requestData['strategy_type']
+        );
+    }
+
+    public function removeStrategyCommand(): RemoveStrategy
+    {
+        Assert::notNull($this->requestData);
+        Assert::keyExists($this->requestData, 'strategy_id');
+        Assert::string($this->requestData['strategy_id']);
+
+        return RemoveStrategy::withFeatureAndStrategyId(
+            $this->featureId,
+            $this->requestData['strategy_id']
+        );
+    }
+
+    public function enableFeatureCommand(): EnableFeature
+    {
+        return EnableFeature::withId($this->featureId);
+    }
+
+    public function disableFeatureCommand(): DisableFeature
+    {
+        return DisableFeature::withId($this->featureId);
+    }
+
+    public function isAddStrategyAction(): bool
+    {
+        return self::ACTION_ADD_STRATEGY === $this->action;
+    }
+
+    public function isRemoveStrategyAction(): bool
+    {
+        return self::ACTION_REMOVE_STRATEGY === $this->action;
+    }
+
+    public function isEnableFeatureAction(): bool
+    {
+        return self::ACTION_ENABLE_FEATURE === $this->action;
+    }
+
+    public function isDisableFeatureAction(): bool
+    {
+        return self::ACTION_DISABLE_FEATURE === $this->action;
+    }
+}

--- a/packages/toggle-crud-psr7-api/src/PostFeature.php
+++ b/packages/toggle-crud-psr7-api/src/PostFeature.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Pheature\Crud\Psr7\Toggle;
 
+use InvalidArgumentException;
 use Pheature\Crud\Toggle\Command\CreateFeature as CreateFeatureCommand;
 use Pheature\Crud\Toggle\Handler\CreateFeature;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Webmozart\Assert\Assert;
 
 final class PostFeature implements RequestHandlerInterface
 {
@@ -24,11 +26,18 @@ final class PostFeature implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $featureId = $request->getAttribute('feature_id');
+
+        try {
+            Assert::string($featureId);
+        } catch (InvalidArgumentException $exception) {
+            return $this->responseFactory->createResponse(404, 'Route Not Found.');
+        }
+
         $this->createFeature->handle(
-            CreateFeatureCommand::disabled($request->getAttribute('feature_id'))
+            CreateFeatureCommand::disabled($featureId)
         );
 
-        return $this->responseFactory->createResponse(201, 'Created');
+        return $this->responseFactory->createResponse(201, 'Created.');
     }
 }
-    

--- a/packages/toggle-crud-psr7-api/test/DeleteFeatureTest.php
+++ b/packages/toggle-crud-psr7-api/test/DeleteFeatureTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Test\Crud\Psr7\Toggle;
+
+use Pheature\Core\Toggle\Write\FeatureId;
+use Pheature\Core\Toggle\Write\FeatureRepository;
+use Pheature\Crud\Psr7\Toggle\DeleteFeature;
+use Pheature\Crud\Toggle\Handler\RemoveFeature;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class DeleteFeatureTest extends TestCase
+{
+    public function testItShouldReturnNotFoundResponseGivenInvalidFeatureId(): void
+    {
+        $featureRepository = $this->createMock(FeatureRepository::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->expects($this->once())
+            ->method('getAttribute')
+            ->with('feature_id')
+            ->willReturn(2354356);
+        $response = $this->createMock(ResponseInterface::class);
+        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
+        $responseFactory->expects($this->once())
+            ->method('createResponse')
+            ->with(404, 'Route Not Found.')
+            ->willReturn($response);
+
+        $handler = new DeleteFeature(new RemoveFeature($featureRepository), $responseFactory);
+        $handler->handle($request);
+    }
+
+    public function testItShouldHandleRequestAndReturnNoContentResponse(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->expects($this->once())
+            ->method('getAttribute')
+            ->with('feature_id')
+            ->willReturn('some_id');
+
+        $featureRepository = $this->createMock(FeatureRepository::class);
+        $featureRepository->expects($this->once())
+            ->method('remove')
+            ->with($this->isInstanceOf(FeatureId::class));
+
+        $response = $this->createMock(ResponseInterface::class);
+        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
+        $responseFactory->expects($this->once())
+            ->method('createResponse')
+            ->with(204)
+            ->willReturn($response);
+
+
+        $handler = new DeleteFeature(new RemoveFeature($featureRepository), $responseFactory);
+        $handler->handle($request);
+    }
+}

--- a/packages/toggle-crud-psr7-api/test/GetFeatureTest.php
+++ b/packages/toggle-crud-psr7-api/test/GetFeatureTest.php
@@ -16,6 +16,26 @@ use Psr\Http\Message\StreamInterface;
 
 final class GetFeatureTest extends TestCase
 {
+    public function testItShouldReturnNotFoundResponseGivenInvalidFeatureId(): void
+    {
+        $finder = $this->createMock(FeatureFinder::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->expects($this->once())
+            ->method('getAttribute')
+            ->with('feature_id')
+            ->willReturn(2354356);
+        $response = $this->createMock(ResponseInterface::class);
+        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
+        $responseFactory->expects($this->once())
+            ->method('createResponse')
+            ->with(404, 'Route Not Found.')
+            ->willReturn($response);
+
+        $requestHandler = new GetFeature($finder, $responseFactory);
+        $requestHandler->handle($request);
+    }
+
+
     public function testItShouldReturnNotFoundResponse(): void
     {
         $finder = $this->createMock(FeatureFinder::class);
@@ -42,6 +62,9 @@ final class GetFeatureTest extends TestCase
     public function testItShouldHandleRequestAndPrepareGetFeatureResponse(): void
     {
         $feature = $this->createMock(Feature::class);
+        $feature->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(['feature_id' => 'some_feature_id']);
         $finder = $this->createMock(FeatureFinder::class);
         $finder->expects($this->once())
             ->method('get')
@@ -50,7 +73,7 @@ final class GetFeatureTest extends TestCase
         $stream = $this->createMock(StreamInterface::class);
         $stream->expects($this->once())
             ->method('write')
-            ->with('{}');
+            ->with('{"feature_id":"some_feature_id"}');
         $response = $this->createMock(ResponseInterface::class);
         $response->expects($this->once())
             ->method('withAddedHeader')

--- a/packages/toggle-crud-psr7-api/test/GetFeaturesTest.php
+++ b/packages/toggle-crud-psr7-api/test/GetFeaturesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pheature\Test\Crud\Psr7\Toggle;
 
+use Pheature\Core\Toggle\Read\Feature;
 use Pheature\Core\Toggle\Read\FeatureFinder;
 use Pheature\Crud\Psr7\Toggle\GetFeatures;
 use PHPUnit\Framework\TestCase;
@@ -16,10 +17,14 @@ final class GetFeaturesTest extends TestCase
 {
     public function testItShouldHandleRequestAndPrepareGetFeaturesResponse(): void
     {
+        $feature = $this->createMock(Feature::class);
+        $feature->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(['hello' => 'world']);
         $finder = $this->createMock(FeatureFinder::class);
         $finder->expects($this->once())
             ->method('all')
-            ->willReturn([['hello' => 'world']]);
+            ->willReturn([$feature]);
         $stream = $this->createMock(StreamInterface::class);
         $stream->expects($this->once())
             ->method('write')

--- a/packages/toggle-crud-psr7-api/test/PatchFeatureTest.php
+++ b/packages/toggle-crud-psr7-api/test/PatchFeatureTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Test\Crud\Psr7\Toggle;
+
+use Pheature\Core\Toggle\Write\Feature;
+use Pheature\Core\Toggle\Write\FeatureId;
+use Pheature\Core\Toggle\Write\FeatureRepository;
+use Pheature\Crud\Psr7\Toggle\PatchFeature;
+use Pheature\Crud\Toggle\Handler\AddStrategy;
+use Pheature\Crud\Toggle\Handler\DisableFeature;
+use Pheature\Crud\Toggle\Handler\EnableFeature;
+use Pheature\Crud\Toggle\Handler\RemoveStrategy;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class PatchFeatureTest extends TestCase
+{
+    /** @var FeatureRepository|MockObject */
+    private FeatureRepository $repository;
+    /** @var MockObject|ResponseFactoryInterface */
+    private ResponseFactoryInterface $responseFactory;
+    private AddStrategy $addStrategy;
+    private RemoveStrategy $removeStrategy;
+    private EnableFeature $enableFeature;
+    private DisableFeature $disableFeature;
+    private PatchFeature $handler;
+
+    public function testItShouldReturnNotFoundResponseGivenInvalidFeatureId(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->expects($this->once())
+            ->method('getAttribute')
+            ->with('feature_id')
+            ->willReturn(2354356);
+        $response = $this->createMock(ResponseInterface::class);
+        $this->responseFactory->expects($this->once())
+            ->method('createResponse')
+            ->with(404, 'Route Not Found.')
+            ->willReturn($response);
+
+        $this->handler->handle($request);
+
+    }
+
+    /** @dataProvider getInvalidRequestData */
+    public function testItShouldReturnBadRequestResponseWhenTheActionIsNotPresent($body): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->expects($this->once())
+            ->method('getAttribute')
+            ->with('feature_id')
+            ->willReturn('some_id');
+        $request->expects($this->once())
+            ->method('getParsedBody')
+            ->willReturn($body);
+
+
+        $response = $this->createMock(ResponseInterface::class);
+        $this->responseFactory->expects($this->once())
+            ->method('createResponse')
+            ->with(400, 'Bad request.')
+            ->willReturn($response);
+
+        $this->handler->handle($request);
+    }
+
+    public function testItShouldHandleAddStrategyRequestAndReturnProcessedResponse(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->expects($this->once())
+            ->method('getAttribute')
+            ->with('feature_id')
+            ->willReturn('some_id');
+        $request->expects($this->once())
+            ->method('getParsedBody')
+            ->willReturn([
+                'action' => 'add_strategy',
+                'value' => [
+                    'strategy_id' => 'some_strategy_id',
+                    'strategy_type' => 'identity_matching_strategy',
+                ],
+            ]);
+
+        $featureId = FeatureId::fromString('some_id');
+        $feature = Feature::withId($featureId);
+        $this->repository->expects($this->once())
+            ->method('get')
+            ->with($this->isInstanceOf(FeatureId::class))
+            ->willReturn($feature);
+        $this->repository->expects($this->once())
+            ->method('save')
+            ->with($feature);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $this->responseFactory->expects($this->once())
+            ->method('createResponse')
+            ->with(202, 'Processed.')
+            ->willReturn($response);
+
+        $this->handler->handle($request);
+    }
+
+    public function testItShouldHandleRemoveStrategyRequestAndReturnProcessedResponse(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->expects($this->once())
+            ->method('getAttribute')
+            ->with('feature_id')
+            ->willReturn('some_id');
+        $request->expects($this->once())
+            ->method('getParsedBody')
+            ->willReturn([
+                'action' => 'remove_strategy',
+                'value' => ['strategy_id' => 'some_strategy_id'],
+            ]);
+
+        $featureId = FeatureId::fromString('some_id');
+        $feature = Feature::withId($featureId);
+        $this->repository->expects($this->once())
+            ->method('get')
+            ->with($this->isInstanceOf(FeatureId::class))
+            ->willReturn($feature);
+        $this->repository->expects($this->once())
+            ->method('save')
+            ->with($feature);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $this->responseFactory->expects($this->once())
+            ->method('createResponse')
+            ->with(202, 'Processed.')
+            ->willReturn($response);
+
+        $this->handler->handle($request);
+    }
+
+    public function testItShouldHandleEnableFeatureRequestAndReturnProcessedResponse(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->expects($this->once())
+            ->method('getAttribute')
+            ->with('feature_id')
+            ->willReturn('some_id');
+        $request->expects($this->once())
+            ->method('getParsedBody')
+            ->willReturn([
+                'action' => 'enable_feature',
+            ]);
+
+        $featureId = FeatureId::fromString('some_id');
+        $feature = Feature::withId($featureId);
+        $this->repository->expects($this->once())
+            ->method('get')
+            ->with($this->isInstanceOf(FeatureId::class))
+            ->willReturn($feature);
+        $this->repository->expects($this->once())
+            ->method('save')
+            ->with($feature);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $this->responseFactory->expects($this->once())
+            ->method('createResponse')
+            ->with(202, 'Processed.')
+            ->willReturn($response);
+
+        $this->assertFalse($feature->isEnabled());
+        $this->handler->handle($request);
+        $this->assertTrue($feature->isEnabled());
+    }
+
+    public function testItShouldHandleDisableFeatureRequestAndReturnProcessedResponse(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->expects($this->once())
+            ->method('getAttribute')
+            ->with('feature_id')
+            ->willReturn('some_id');
+        $request->expects($this->once())
+            ->method('getParsedBody')
+            ->willReturn([
+                'action' => 'disable_feature',
+            ]);
+
+        $featureId = FeatureId::fromString('some_id');
+        $feature = Feature::withId($featureId);
+        $feature->enable();
+        $this->repository->expects($this->once())
+            ->method('get')
+            ->with($this->isInstanceOf(FeatureId::class))
+            ->willReturn($feature);
+        $this->repository->expects($this->once())
+            ->method('save')
+            ->with($feature);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $this->responseFactory->expects($this->once())
+            ->method('createResponse')
+            ->with(202, 'Processed.')
+            ->willReturn($response);
+
+        $this->assertTrue($feature->isEnabled());
+        $this->handler->handle($request);
+        $this->assertFalse($feature->isEnabled());
+    }
+
+    public function getInvalidRequestData(): array
+    {
+        return [
+            'null request body' => [
+                null,
+            ],
+            'object request body' => [
+                new \StdClass(),
+            ],
+            'no action present in request body' => [
+                ['feature_id' => 'some_id']
+            ],
+            'array type action present in request body' => [
+                ['action' => []]
+            ],
+            'invalid value for add_strategy action' => [
+                ['action' => 'add_strategy', 'value' => []]
+            ],
+            'null value for add_strategy action' => [
+                ['action' => 'add_strategy', 'value' => null]
+            ],
+            'string value for add_strategy action' => [
+                ['action' => 'add_strategy', 'value' => 'hello world!!']
+            ],
+            'null strategy_id value for add_strategy action' => [
+                ['action' => 'add_strategy', 'value' => ['strategy_id' => null, 'strategy_type' => 'some_type']]
+            ],
+            'invalid strategy_id value for add_strategy action' => [
+                ['action' => 'add_strategy', 'value' => ['strategy_id' => [], 'strategy_type' => 'some_type']]
+            ],
+            'not strategy_id for add_strategy action' => [
+                ['action' => 'add_strategy', 'value' => ['strategy_type' => 'some_type']]
+            ],
+            'not strategy_type for add_strategy action' => [
+                ['action' => 'add_strategy', 'value' => ['strategy_id' => 'some_id']]
+            ],
+            'null strategy_type value for add_strategy action' => [
+                ['action' => 'add_strategy', 'value' => ['strategy_id' => 'some_id', 'strategy_type' => null]]
+            ],
+            'invalid strategy_type value for add_strategy action' => [
+                ['action' => 'add_strategy', 'value' => ['strategy_id' => 'some_id', 'strategy_type' => []]]
+            ],
+            'object strategy_type value for add_strategy action' => [
+                ['action' => 'add_strategy', 'value' => ['strategy_id' => 'some_id', 'strategy_type' => new \StdClass()]]
+            ],
+            'invalid value for remove_strategy action' => [
+                ['action' => 'remove_strategy', 'value' => []]
+            ],
+            'null value for remove_strategy action' => [
+                ['action' => 'remove_strategy', 'value' => null]
+            ],
+            'null strategy_id value for remove_strategy action' => [
+                ['action' => 'remove_strategy', 'value' => ['strategy_id' => null]]
+            ],
+            'invalid strategy_id value for remove_strategy action' => [
+                ['action' => 'remove_strategy', 'value' => ['strategy_id' => []]]
+            ],
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->createMock(FeatureRepository::class);
+        $this->responseFactory = $this->createMock(ResponseFactoryInterface::class);
+        $this->addStrategy = new AddStrategy($this->repository);
+        $this->removeStrategy = new RemoveStrategy($this->repository);
+        $this->enableFeature = new EnableFeature($this->repository);
+        $this->disableFeature = new DisableFeature($this->repository);
+        $this->handler = new PatchFeature(
+            $this->addStrategy,
+            $this->removeStrategy,
+            $this->enableFeature,
+            $this->disableFeature,
+            $this->responseFactory
+        );
+    }
+}

--- a/packages/toggle-crud-psr7-api/test/PostFeatureTest.php
+++ b/packages/toggle-crud-psr7-api/test/PostFeatureTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Test\Crud\Psr7\Toggle;
+
+use Pheature\Core\Toggle\Write\Feature;
+use Pheature\Core\Toggle\Write\FeatureRepository;
+use Pheature\Crud\Psr7\Toggle\PostFeature;
+use Pheature\Crud\Toggle\Handler\CreateFeature;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class PostFeatureTest extends TestCase
+{
+    public function testItShouldReturnNotFoundResponseGivenInvalidFeatureId(): void
+    {
+        $featureRepository = $this->createMock(FeatureRepository::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->expects($this->once())
+            ->method('getAttribute')
+            ->with('feature_id')
+            ->willReturn(2354356);
+        $response = $this->createMock(ResponseInterface::class);
+        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
+        $responseFactory->expects($this->once())
+            ->method('createResponse')
+            ->with(404, 'Route Not Found.')
+            ->willReturn($response);
+
+        $handler = new PostFeature(new CreateFeature($featureRepository), $responseFactory);
+        $handler->handle($request);
+    }
+
+    public function testItShouldHandleRequestAndReturnCreatedResponse(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->expects($this->once())
+            ->method('getAttribute')
+            ->with('feature_id')
+            ->willReturn('some_id');
+
+        $featureRepository = $this->createMock(FeatureRepository::class);
+        $featureRepository->expects($this->once())
+            ->method('save')
+            ->with($this->isInstanceOf(Feature::class));
+
+        $response = $this->createMock(ResponseInterface::class);
+        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
+        $responseFactory->expects($this->once())
+            ->method('createResponse')
+            ->with(201, 'Created.')
+            ->willReturn($response);
+
+        $handler = new PostFeature(new CreateFeature($featureRepository), $responseFactory);
+        $handler->handle($request);
+    }
+}


### PR DESCRIPTION
Closes issues https://github.com/pheature-flags/pheature-flags/issues/86, https://github.com/pheature-flags/pheature-flags/issues/87, and https://github.com/pheature-flags/pheature-flags/issues/88. also closes as deprecated https://github.com/pheature-flags/toggle-crud-psr7-api/pull/2, the other repositories are only mirrors from main repo;-D

- [x] Fix broken tests
- [x] Add tests to PostFeature
- [x] Add tests to PatchFeature
- [x] Add tests to DeleteFeature