### PR TITLE
[Toggle PSR-11 Factories] Add static version to PostFeatureFactory

### DIFF
--- a/packages/toggle-crud-psr11-factories/src/PostFeatureFactory.php
+++ b/packages/toggle-crud-psr11-factories/src/PostFeatureFactory.php
@@ -18,6 +18,11 @@ final class PostFeatureFactory
         /** @var ResponseFactoryInterface $responseFactory */
         $responseFactory = $container->get(ResponseFactoryInterface::class);
 
+        return self::create($createFeature, $responseFactory);
+    }
+
+    public static function create(CreateFeature $createFeature, ResponseFactoryInterface $responseFactory): PostFeature
+    {
         return new PostFeature($createFeature, $responseFactory);
     }
 }

--- a/packages/toggle-crud-psr11-factories/test/PostFeatureFactoryTest.php
+++ b/packages/toggle-crud-psr11-factories/test/PostFeatureFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Pheature\Test\Crud\Psr11\Toggle;
+
+use Pheature\Core\Toggle\Write\FeatureRepository;
+use Pheature\Crud\Psr11\Toggle\PostFeatureFactory;
+use Pheature\Crud\Psr7\Toggle\PostFeature;
+use Pheature\Crud\Toggle\Handler\CreateFeature;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final class PostFeatureFactoryTest extends TestCase
+{
+    public function testItShouldCreateAPostFeatureFromInvokable(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $createFeature = new CreateFeature($this->createMock(FeatureRepository::class));
+        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
+
+        $container
+            ->expects(self::exactly(2))
+            ->method('get')
+            ->withConsecutive([CreateFeature::class], [ResponseFactoryInterface::class])
+            ->willReturnOnConsecutiveCalls($createFeature, $responseFactory);
+
+        $factory = new PostFeatureFactory();
+        $actual = $factory->__invoke($container);
+
+        self::assertInstanceOf(PostFeature::class, $actual);
+    }
+
+    public function testItShouldCreateAPostFeatureFromCreate(): void
+    {
+        $createFeature = new CreateFeature($this->createMock(FeatureRepository::class));
+        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
+
+        $actual = PostFeatureFactory::create(
+            $createFeature,
+            $responseFactory
+        );
+
+        self::assertInstanceOf(PostFeature::class, $actual);
+    }
+}


### PR DESCRIPTION
It closes #133 and also adds the phpspec/prophecy mocking library as commented [here](https://github.com/pheature-flags/pheature-flags/discussions/154). The only drawback is that checking in this issue if it was possible the mock of the final class `CreateFeature` I realise that it was not possible :(

If the benefit of mocking `final` classes was the point to move on this library, we can remove the library and use mocks with PhpUnit as we've done with others ;)
