### PR TITLE
[#179] Implement a ChainFeatureFinder

### DIFF
--- a/packages/toggle-core/src/Exception/FeatureNotFoundInChainException.php
+++ b/packages/toggle-core/src/Exception/FeatureNotFoundInChainException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Core\Toggle\Exception;
+
+use Exception;
+
+class FeatureNotFoundInChainException extends Exception implements FeatureNotFoundException
+{
+    public static function withId(string $featureId): FeatureNotFoundException
+    {
+        return new self(
+            sprintf('Feature with id %s not found in chain', $featureId)
+        );
+    }
+}

--- a/packages/toggle-core/src/Read/ChainFeatureFinder.php
+++ b/packages/toggle-core/src/Read/ChainFeatureFinder.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Core\Toggle\Read;
+
+use Pheature\Core\Toggle\Exception\FeatureNotFoundException;
+use Pheature\Core\Toggle\Exception\FeatureNotFoundInChainException;
+
+class ChainFeatureFinder implements FeatureFinder
+{
+    /** @var FeatureFinder[] */
+    private array $featureFinders;
+
+    public function __construct(FeatureFinder ...$featureFinders)
+    {
+        $this->featureFinders = $featureFinders;
+    }
+
+    public function get(string $featureId): Feature
+    {
+        foreach ($this->featureFinders as $featureFinder) {
+            try {
+                return $featureFinder->get($featureId);
+            } catch (FeatureNotFoundException $exception) {
+            }
+        }
+
+        throw FeatureNotFoundInChainException::withId($featureId);
+    }
+
+    public function all(): array
+    {
+        $features = [];
+
+        foreach ($this->featureFinders as $featureFinder) {
+            $features = array_merge($features, $featureFinder->all());
+        }
+
+        return $features;
+    }
+}

--- a/packages/toggle-core/test/Read/ChainFeatureFinderTest.php
+++ b/packages/toggle-core/test/Read/ChainFeatureFinderTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Test\Core\Toggle\Read;
+
+use Pheature\Core\Toggle\Exception\FeatureNotFoundException;
+use Pheature\Core\Toggle\Exception\FeatureNotFoundInChainException;
+use Pheature\Core\Toggle\Read\ChainFeatureFinder;
+use Pheature\Core\Toggle\Read\Feature;
+use Pheature\Core\Toggle\Read\FeatureFinder;
+use PHPUnit\Framework\TestCase;
+
+class ChainFeatureFinderTest extends TestCase
+{
+    private const FEATURE_ID = 'my_feature';
+
+    public function testItShouldThrowAnExceptionWhenFeatureCannotBeFoundInAnyFeatureFinder(): void
+    {
+        $featureNotFoundException = $this->createMock(FeatureNotFoundException::class);
+
+        $firstFeatureFinder = $this->createMock(FeatureFinder::class);
+        $firstFeatureFinder
+            ->expects(self::once())
+            ->method('get')
+            ->willThrowException($featureNotFoundException);
+
+        $secondFeatureFinder = $this->createMock(FeatureFinder::class);
+        $secondFeatureFinder
+            ->expects(self::once())
+            ->method('get')
+            ->willThrowException($featureNotFoundException);
+
+        $chain = new ChainFeatureFinder(
+            $firstFeatureFinder,
+            $secondFeatureFinder
+        );
+
+        $this->expectException(FeatureNotFoundInChainException::class);
+
+        $chain->get(self::FEATURE_ID);
+    }
+
+    public function testItShouldGetTheFeatureByFeatureIdFromTheFirstFinder(): void
+    {
+        $expectedFeature = $this->createMock(Feature::class);
+
+        $firstFeatureFinder = $this->createMock(FeatureFinder::class);
+        $firstFeatureFinder
+            ->expects(self::once())
+            ->method('get')
+            ->willReturn($expectedFeature);
+
+        $secondFeatureFinder = $this->createMock(FeatureFinder::class);
+        $secondFeatureFinder
+            ->expects(self::never())
+            ->method('get');
+
+        $chain = new ChainFeatureFinder(
+            $firstFeatureFinder,
+            $secondFeatureFinder
+        );
+
+        $actual = $chain->get(self::FEATURE_ID);
+
+        self::assertSame($expectedFeature, $actual);
+    }
+
+    public function testItShouldGetTheFeatureByFeatureIdFromTheSecondFinder(): void
+    {
+        $firstFeatureFinder = $this->createMock(FeatureFinder::class);
+        $firstFeatureFinder
+            ->expects(self::once())
+            ->method('get')
+            ->willThrowException($this->createMock(FeatureNotFoundException::class));
+
+        $expectedFeature = $this->createMock(Feature::class);
+
+        $secondFeatureFinder = $this->createMock(FeatureFinder::class);
+        $secondFeatureFinder
+            ->expects(self::once())
+            ->method('get')
+            ->willReturn($expectedFeature);
+
+        $chain = new ChainFeatureFinder(
+            $firstFeatureFinder,
+            $secondFeatureFinder
+        );
+
+        $actual = $chain->get(self::FEATURE_ID);
+
+        self::assertSame($expectedFeature, $actual);
+    }
+
+    public function testItShouldReturnAllFeaturesFromAllFinders(): void
+    {
+        $firstFeature = $this->createMock(Feature::class);
+        $secondFeature = $this->createMock(Feature::class);
+        $thirdFeature = $this->createMock(Feature::class);
+        $fourthFeature = $this->createMock(Feature::class);
+
+        $expectedFeatures = [
+            $firstFeature,
+            $secondFeature,
+            $thirdFeature,
+            $fourthFeature
+        ];
+
+        $firstFeatureFinder = $this->createMock(FeatureFinder::class);
+        $firstFeatureFinder
+            ->expects(self::once())
+            ->method('all')
+            ->willReturn([$firstFeature, $thirdFeature]);
+
+        $secondFeatureFinder = $this->createMock(FeatureFinder::class);
+        $secondFeatureFinder
+            ->expects(self::once())
+            ->method('all')
+            ->willReturn([$secondFeature, $fourthFeature]);
+
+        $chain = new ChainFeatureFinder(
+            $firstFeatureFinder,
+            $secondFeatureFinder
+        );
+
+        $actual = $chain->all();
+
+        self::assertCount(count($expectedFeatures), $actual);
+    }
+
+    public function testItShouldReturnAnEmptyArrayIfNoFeaturesFoundInFinders(): void
+    {
+        $firstFeatureFinder = $this->createMock(FeatureFinder::class);
+        $firstFeatureFinder
+            ->expects(self::once())
+            ->method('all')
+            ->willReturn([]);
+
+        $secondFeatureFinder = $this->createMock(FeatureFinder::class);
+        $secondFeatureFinder
+            ->expects(self::once())
+            ->method('all')
+            ->willReturn([]);
+
+        $chain = new ChainFeatureFinder(
+            $firstFeatureFinder,
+            $secondFeatureFinder
+        );
+
+        $actual = $chain->all();
+
+        self::assertSame([], $actual);
+    }
+}


### PR DESCRIPTION
The idea of this implementation is what you proposed in the #179 about creating a `ChainFeatureFinder` where you can inject multiple `FeatureFinder` instances where each one can retrieve features from different sources (in_memory, mysql...).

It's a really basic implementation but I think it covers the problem. The only thing could happen is that multiple sources contain the same `featureId`, because the first finder with the feature will return the feature.