### PR TITLE
HOTFIX: load compiler passes from bundle class

### DIFF
--- a/packages/symfony-toggle/src/DependencyInjection/PheatureFlagsExtension.php
+++ b/packages/symfony-toggle/src/DependencyInjection/PheatureFlagsExtension.php
@@ -8,9 +8,7 @@ use Doctrine\DBAL\Connection;
 use Pheature\Core\Toggle\Read\ChainToggleStrategyFactory;
 use Pheature\Core\Toggle\Read\FeatureFinder;
 use Pheature\Core\Toggle\Read\Toggle;
-use Pheature\Core\Toggle\Write\FeatureRepository;
 use Pheature\Crud\Psr11\Toggle\FeatureFinderFactory;
-use Pheature\Crud\Psr11\Toggle\FeatureRepositoryFactory;
 use Pheature\Crud\Psr11\Toggle\ToggleConfig;
 use Pheature\InMemory\Toggle\InMemoryFeatureFactory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -50,10 +48,6 @@ final class PheatureFlagsExtension extends ConfigurableExtension
                 ->setLazy(true)
                 ->addArgument(new Reference(ChainToggleStrategyFactory::class));
         }
-
-        $container->addCompilerPass(new SegmentFactoryPass());
-        $container->addCompilerPass(new ToggleStrategyFactoryPass());
-        $container->addCompilerPass(new FeatureRepositoryFactoryPass());
 
         $container->register(Toggle::class, Toggle::class)
             ->setAutowired(false)

--- a/packages/symfony-toggle/src/PheatureFlagsBundle.php
+++ b/packages/symfony-toggle/src/PheatureFlagsBundle.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Pheature\Community\Symfony;
 
+use Pheature\Community\Symfony\DependencyInjection\FeatureRepositoryFactoryPass;
+use Pheature\Community\Symfony\DependencyInjection\SegmentFactoryPass;
+use Pheature\Community\Symfony\DependencyInjection\ToggleStrategyFactoryPass;
 use Pheature\Model\Toggle\EnableByMatchingIdentityId;
 use Pheature\Model\Toggle\EnableByMatchingSegment;
 use Pheature\Model\Toggle\IdentitySegment;
@@ -44,5 +47,9 @@ final class PheatureFlagsBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         $container->loadFromExtension('pheature_flags', self::DEFAULT_CONFIG);
+
+        $container->addCompilerPass(new SegmentFactoryPass());
+        $container->addCompilerPass(new ToggleStrategyFactoryPass());
+        $container->addCompilerPass(new FeatureRepositoryFactoryPass());
     }
 }


### PR DESCRIPTION
Symfony bundle fails because compiler passes cannot be loaded from the extension class, they must be loaded from the bundle class.