### PR TITLE
[#178][Symfony-toggle] Create Toggle API Compiler pass

### DIFF
--- a/docs/getting-started/symfony-bundle.md
+++ b/docs/getting-started/symfony-bundle.md
@@ -32,7 +32,7 @@ return [
 # config/packages/pheature-flags.yaml
 pheature_flags:
   driver:               ~ # One of "inmemory"; "dbal"
-  prefix:               ''
+  api_prefix:           ''
   segment_types:
     - { type: 'identity_segment', factory_id: 'Pheature\Model\Toggle\SegmentFactory' }
     - { type: 'strict_matching_segment', factory_id: 'Pheature\Model\Toggle\SegmentFactory' }

--- a/packages/laravel-toggle/config/pheature_flags.php
+++ b/packages/laravel-toggle/config/pheature_flags.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 return [
-    'prefix' => '',
+    'api_prefix' => '',
     'driver' => 'inmemory',
     'toggles' => [
         'feature_1' => [

--- a/packages/laravel-toggle/src/ToggleProvider.php
+++ b/packages/laravel-toggle/src/ToggleProvider.php
@@ -128,7 +128,7 @@ final class ToggleProvider extends ServiceProvider
     private function routeConfiguration(): array
     {
         return [
-            'prefix' => config('pheature_flags.prefix') ?? '',
+            'prefix' => config('pheature_flags.api_prefix') ?? '',
             'middleware' => config('pheature_flags.middleware') ?? ['api'],
         ];
     }

--- a/packages/mezzio-toggle/src/RouterDelegator.php
+++ b/packages/mezzio-toggle/src/RouterDelegator.php
@@ -25,7 +25,7 @@ final class RouterDelegator
 
         /** @var ToggleConfig $config */
         $config = $container->get(ToggleConfig::class);
-        $path = sprintf('%s/features', $config->prefix());
+        $path = sprintf('%s/features', $config->apiPrefix());
         $pathWithId = sprintf('%s/{feature_id}', $path);
 
         $app->get($path, [GetFeatures::class], 'get_features');

--- a/packages/symfony-toggle/composer.json
+++ b/packages/symfony-toggle/composer.json
@@ -15,16 +15,15 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
+        "pheature/inmemory-toggle": "@dev",
         "pheature/toggle-core": "@dev",
         "pheature/toggle-crud-psr11-factories": "@dev",
-        "pheature/toggle-model": "@dev",
-        "symfony/framework-bundle": "~5.0"
+        "pheature/toggle-model": "@dev"
     },
     "require-dev": {
         "doctrine/dbal": "^3.1",
         "infection/infection": "^0.21.0",
         "pheature/dbal-toggle": "@dev",
-        "pheature/inmemory-toggle": "@dev",
         "pheature/toggle-crud": "@dev",
         "pheature/toggle-crud-psr7-api": "@dev",
         "phpro/grumphp": "^1.0",

--- a/packages/symfony-toggle/composer.json
+++ b/packages/symfony-toggle/composer.json
@@ -15,15 +15,16 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "pheature/inmemory-toggle": "@dev",
         "pheature/toggle-core": "@dev",
         "pheature/toggle-crud-psr11-factories": "@dev",
-        "pheature/toggle-model": "@dev"
+        "pheature/toggle-model": "@dev",
+        "symfony/framework-bundle": "~5.0"
     },
     "require-dev": {
         "doctrine/dbal": "^3.1",
         "infection/infection": "^0.21.0",
         "pheature/dbal-toggle": "@dev",
+        "pheature/inmemory-toggle": "@dev",
         "pheature/toggle-crud": "@dev",
         "pheature/toggle-crud-psr7-api": "@dev",
         "phpro/grumphp": "^1.0",

--- a/packages/symfony-toggle/src/DependencyInjection/Configuration.php
+++ b/packages/symfony-toggle/src/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ final class Configuration implements ConfigurationInterface
             ->enumNode('driver')
                 ->values(['inmemory', 'dbal'])
             ->end()
-            ->scalarNode('prefix')
+            ->scalarNode('api_prefix')
                 ->defaultValue('')
             ->end()
             ->booleanNode('api_enabled')

--- a/packages/symfony-toggle/src/DependencyInjection/Configuration.php
+++ b/packages/symfony-toggle/src/DependencyInjection/Configuration.php
@@ -26,6 +26,9 @@ final class Configuration implements ConfigurationInterface
             ->scalarNode('prefix')
                 ->defaultValue('')
             ->end()
+            ->booleanNode('api_enabled')
+                ->defaultFalse()
+            ->end()
         ->end();
 
         $this->addStrategyTypes($rootNode);

--- a/packages/symfony-toggle/src/DependencyInjection/ToggleAPIPass.php
+++ b/packages/symfony-toggle/src/DependencyInjection/ToggleAPIPass.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Community\Symfony\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+final class ToggleAPIPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        /** @var array<array<mixed>> $pheatureFlagsConfig */
+        $pheatureFlagsConfig = $container->getExtensionConfig('pheature_flags');
+        $mergedConfig = array_merge(...$pheatureFlagsConfig);
+
+        if (false === $mergedConfig['api_enabled']) {
+            return;
+        }
+
+        $loader = new YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/../Resources/config/toggle_api')
+        );
+        $loader->load('services/controller_services.yaml');
+        $loader->load('services/handler_services.yaml');
+    }
+}

--- a/packages/symfony-toggle/src/DependencyInjection/ToggleAPIPass.php
+++ b/packages/symfony-toggle/src/DependencyInjection/ToggleAPIPass.php
@@ -21,6 +21,8 @@ final class ToggleAPIPass implements CompilerPassInterface
             return;
         }
 
+        $container->getParameterBag()->set('pheature_flags_prefix', $mergedConfig['api_prefix']);
+
         $loader = new YamlFileLoader(
             $container,
             new FileLocator(__DIR__ . '/../Resources/config/toggle_api')

--- a/packages/symfony-toggle/src/DependencyInjection/ToggleAPIPass.php
+++ b/packages/symfony-toggle/src/DependencyInjection/ToggleAPIPass.php
@@ -15,6 +15,7 @@ final class ToggleAPIPass implements CompilerPassInterface
     {
         /** @var array<array<mixed>> $pheatureFlagsConfig */
         $pheatureFlagsConfig = $container->getExtensionConfig('pheature_flags');
+
         $mergedConfig = array_merge(...$pheatureFlagsConfig);
 
         if (false === $mergedConfig['api_enabled']) {

--- a/packages/symfony-toggle/src/PheatureFlagsBundle.php
+++ b/packages/symfony-toggle/src/PheatureFlagsBundle.php
@@ -7,6 +7,7 @@ namespace Pheature\Community\Symfony;
 use Pheature\Community\Symfony\DependencyInjection\FeatureRepositoryFactoryPass;
 use Pheature\Community\Symfony\DependencyInjection\SegmentFactoryPass;
 use Pheature\Community\Symfony\DependencyInjection\ToggleStrategyFactoryPass;
+use Pheature\Community\Symfony\DependencyInjection\ToggleAPIPass;
 use Pheature\Model\Toggle\EnableByMatchingIdentityId;
 use Pheature\Model\Toggle\EnableByMatchingSegment;
 use Pheature\Model\Toggle\IdentitySegment;
@@ -21,6 +22,7 @@ final class PheatureFlagsBundle extends Bundle
     private const DEFAULT_CONFIG = [
         'driver' => 'inmemory',
         'prefix' => '',
+        'api_enabled' => false,
         'segment_types' => [
             [
                 'type' => IdentitySegment::NAME,
@@ -51,5 +53,6 @@ final class PheatureFlagsBundle extends Bundle
         $container->addCompilerPass(new SegmentFactoryPass());
         $container->addCompilerPass(new ToggleStrategyFactoryPass());
         $container->addCompilerPass(new FeatureRepositoryFactoryPass());
+        $container->addCompilerPass(new ToggleAPIPass());
     }
 }

--- a/packages/symfony-toggle/src/PheatureFlagsBundle.php
+++ b/packages/symfony-toggle/src/PheatureFlagsBundle.php
@@ -21,7 +21,7 @@ final class PheatureFlagsBundle extends Bundle
 {
     private const DEFAULT_CONFIG = [
         'driver' => 'inmemory',
-        'prefix' => '',
+        'api_prefix' => '',
         'api_enabled' => false,
         'segment_types' => [
             [

--- a/packages/symfony-toggle/src/Resources/config/toggle_api/routes.yaml
+++ b/packages/symfony-toggle/src/Resources/config/toggle_api/routes.yaml
@@ -1,0 +1,24 @@
+pheature_flags_toggle_detail:
+  methods: [GET]
+  path: /features/{feature_id}
+  controller: Pheature\Crud\Psr7\Toggle\GetFeature::handle
+
+pheature_flags_feature_list:
+  methods: [GET]
+  path: /features
+  controller: Pheature\Crud\Psr7\Toggle\GetFeatures::handle
+
+pheature_flags_feature_create:
+  methods: [POST]
+  path: /features/{feature_id}
+  controller: Pheature\Crud\Psr7\Toggle\PostFeature::handle
+
+pheature_flags_feature_update:
+  methods: [PATCH]
+  path: /features/{feature_id}
+  controller: Pheature\Crud\Psr7\Toggle\PatchFeature::handle
+
+pheature_flags_feature_remove:
+  methods: [DELETE]
+  path: /features/{feature_id}
+  controller: Pheature\Crud\Psr7\Toggle\DeleteFeature::handle

--- a/packages/symfony-toggle/src/Resources/config/toggle_api/services/controller_services.yaml
+++ b/packages/symfony-toggle/src/Resources/config/toggle_api/services/controller_services.yaml
@@ -1,0 +1,44 @@
+services:
+  _defaults:
+    autowire: false
+    autoconfigure: false
+    public: true
+
+  # PSR Controllers
+  Pheature\Crud\Psr7\Toggle\GetFeatures:
+    class: Pheature\Crud\Psr7\Toggle\GetFeatures
+    arguments:
+      - '@Pheature\Core\Toggle\Read\FeatureFinder'
+      - '@Psr\Http\Message\ResponseFactoryInterface'
+    tags: [ 'controller.service_arguments' ]
+
+  Pheature\Crud\Psr7\Toggle\GetFeature:
+    class: Pheature\Crud\Psr7\Toggle\GetFeature
+    arguments:
+      - '@Pheature\Core\Toggle\Read\FeatureFinder'
+      - '@Psr\Http\Message\ResponseFactoryInterface'
+    tags: [ 'controller.service_arguments' ]
+
+  Pheature\Crud\Psr7\Toggle\PostFeature:
+    class: Pheature\Crud\Psr7\Toggle\PostFeature
+    arguments:
+      - '@Pheature\Crud\Toggle\Handler\CreateFeature'
+      - '@Psr\Http\Message\ResponseFactoryInterface'
+    tags: [ 'controller.service_arguments' ]
+
+  Pheature\Crud\Psr7\Toggle\PatchFeature:
+    class: Pheature\Crud\Psr7\Toggle\PatchFeature
+    arguments:
+      - '@Pheature\Crud\Toggle\Handler\AddStrategy'
+      - '@Pheature\Crud\Toggle\Handler\RemoveStrategy'
+      - '@Pheature\Crud\Toggle\Handler\EnableFeature'
+      - '@Pheature\Crud\Toggle\Handler\DisableFeature'
+      - '@Psr\Http\Message\ResponseFactoryInterface'
+    tags: [ 'controller.service_arguments' ]
+
+  Pheature\Crud\Psr7\Toggle\DeleteFeature:
+    class: Pheature\Crud\Psr7\Toggle\DeleteFeature
+    arguments:
+      - '@Pheature\Crud\Toggle\Handler\RemoveFeature'
+      - '@Psr\Http\Message\ResponseFactoryInterface'
+    tags: [ 'controller.service_arguments' ]

--- a/packages/symfony-toggle/src/Resources/config/toggle_api/services/handler_services.yaml
+++ b/packages/symfony-toggle/src/Resources/config/toggle_api/services/handler_services.yaml
@@ -1,0 +1,34 @@
+services:
+  _defaults:
+    autowire: false
+    autoconfigure: false
+
+  Pheature\Crud\Toggle\Handler\CreateFeature:
+    class: Pheature\Crud\Toggle\Handler\CreateFeature
+    arguments:
+      - '@Pheature\Core\Toggle\Write\FeatureRepository'
+
+  Pheature\Crud\Toggle\Handler\AddStrategy:
+    class: Pheature\Crud\Toggle\Handler\AddStrategy
+    arguments:
+      - '@Pheature\Core\Toggle\Write\FeatureRepository'
+
+  Pheature\Crud\Toggle\Handler\RemoveStrategy:
+    class: Pheature\Crud\Toggle\Handler\RemoveStrategy
+    arguments:
+      - '@Pheature\Core\Toggle\Write\FeatureRepository'
+
+  Pheature\Crud\Toggle\Handler\EnableFeature:
+    class: Pheature\Crud\Toggle\Handler\EnableFeature
+    arguments:
+      - '@Pheature\Core\Toggle\Write\FeatureRepository'
+
+  Pheature\Crud\Toggle\Handler\DisableFeature:
+    class: Pheature\Crud\Toggle\Handler\DisableFeature
+    arguments:
+      - '@Pheature\Core\Toggle\Write\FeatureRepository'
+
+  Pheature\Crud\Toggle\Handler\RemoveFeature:
+    class: Pheature\Crud\Toggle\Handler\RemoveFeature
+    arguments:
+      - '@Pheature\Core\Toggle\Write\FeatureRepository'

--- a/packages/symfony-toggle/test/DependencyInjection/ConfigurationTest.php
+++ b/packages/symfony-toggle/test/DependencyInjection/ConfigurationTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 
-class ConfigurationTest extends TestCase
+final class ConfigurationTest extends TestCase
 {
     /** @dataProvider validConfigurations */
     public function testItShouldReturnAConfiguration(array $actualConfig, array $expectedConfig): void

--- a/packages/symfony-toggle/test/DependencyInjection/ConfigurationTest.php
+++ b/packages/symfony-toggle/test/DependencyInjection/ConfigurationTest.php
@@ -38,6 +38,7 @@ class ConfigurationTest extends TestCase
             'user config' => [],
             'expected config' => [
                 'prefix' => '',
+                'api_enabled' => false,
                 'strategy_types' => [],
                 'segment_types' => [],
                 'toggles' => [],
@@ -52,6 +53,7 @@ class ConfigurationTest extends TestCase
             ],
             'expected config' => [
                 'prefix' => 'myapp',
+                'api_enabled' => false,
                 'strategy_types' => [],
                 'segment_types' => [],
                 'toggles' => [],
@@ -66,6 +68,7 @@ class ConfigurationTest extends TestCase
             ],
             'expected config' => [
                 'prefix' => '',
+                'api_enabled' => false,
                 'driver' => 'dbal',
                 'strategy_types' => [],
                 'segment_types' => [],
@@ -86,6 +89,7 @@ class ConfigurationTest extends TestCase
             ],
             'expected config' => [
                 'prefix' => '',
+                'api_enabled' => false,
                 'strategy_types' => [
                     [
                         'type' => 'my_strategy_type',
@@ -110,6 +114,7 @@ class ConfigurationTest extends TestCase
             ],
             'expected config' => [
                 'prefix' => '',
+                'api_enabled' => false,
                 'strategy_types' => [],
                 'segment_types' => [
                     [
@@ -149,6 +154,7 @@ class ConfigurationTest extends TestCase
             ],
             'expected config' => [
                 'prefix' => '',
+                'api_enabled' => false,
                 'strategy_types' => [],
                 'segment_types' => [],
                 'toggles' => [

--- a/packages/symfony-toggle/test/DependencyInjection/ConfigurationTest.php
+++ b/packages/symfony-toggle/test/DependencyInjection/ConfigurationTest.php
@@ -37,7 +37,7 @@ final class ConfigurationTest extends TestCase
         yield 'user does not define any config' => [
             'user config' => [],
             'expected config' => [
-                'prefix' => '',
+                'api_prefix' => '',
                 'api_enabled' => false,
                 'strategy_types' => [],
                 'segment_types' => [],
@@ -45,14 +45,14 @@ final class ConfigurationTest extends TestCase
             ]
         ];
 
-        yield 'user defines only the prefix' => [
+        yield 'user defines only the api_prefix' => [
             'user config' => [
                 'pheature_flags' => [
-                    'prefix' => 'myapp',
+                    'api_prefix' => 'myapp',
                 ],
             ],
             'expected config' => [
-                'prefix' => 'myapp',
+                'api_prefix' => 'myapp',
                 'api_enabled' => false,
                 'strategy_types' => [],
                 'segment_types' => [],
@@ -67,7 +67,7 @@ final class ConfigurationTest extends TestCase
                 ],
             ],
             'expected config' => [
-                'prefix' => '',
+                'api_prefix' => '',
                 'api_enabled' => false,
                 'driver' => 'dbal',
                 'strategy_types' => [],
@@ -88,7 +88,7 @@ final class ConfigurationTest extends TestCase
                 ],
             ],
             'expected config' => [
-                'prefix' => '',
+                'api_prefix' => '',
                 'api_enabled' => false,
                 'strategy_types' => [
                     [
@@ -113,7 +113,7 @@ final class ConfigurationTest extends TestCase
                 ],
             ],
             'expected config' => [
-                'prefix' => '',
+                'api_prefix' => '',
                 'api_enabled' => false,
                 'strategy_types' => [],
                 'segment_types' => [
@@ -153,7 +153,7 @@ final class ConfigurationTest extends TestCase
                 ],
             ],
             'expected config' => [
-                'prefix' => '',
+                'api_prefix' => '',
                 'api_enabled' => false,
                 'strategy_types' => [],
                 'segment_types' => [],

--- a/packages/symfony-toggle/test/DependencyInjection/FeatureRepositoryFactoryPassTest.php
+++ b/packages/symfony-toggle/test/DependencyInjection/FeatureRepositoryFactoryPassTest.php
@@ -19,7 +19,7 @@ final class FeatureRepositoryFactoryPassTest extends TestCase
         $container = TestContainerFactory::create($compilerPass);
         $container->register(ToggleConfig::class, ToggleConfig::class)->addArgument([
             'driver' => 'inmemory',
-            'prefix' => '',
+            'api_prefix' => '',
         ]);
 
         $featureRepositoryFactoryDefinition = $container->getDefinition(FeatureRepository::class);
@@ -37,7 +37,7 @@ final class FeatureRepositoryFactoryPassTest extends TestCase
         $container = TestContainerFactory::create($compilerPass, 'dbal');
         $container->register(ToggleConfig::class, ToggleConfig::class)->addArgument([
             'driver' => 'dbal',
-            'prefix' => '',
+            'api_prefix' => '',
         ]);
         $container->register(Connection::class, Connection::class)
             ->setFactory([DriverManager::class, 'getConnection'])

--- a/packages/symfony-toggle/test/DependencyInjection/Fixtures/PheatureFlagsConfig.php
+++ b/packages/symfony-toggle/test/DependencyInjection/Fixtures/PheatureFlagsConfig.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Test\Community\Symfony\DependencyInjection\Fixtures;
+
+use Pheature\Model\Toggle\EnableByMatchingIdentityId;
+use Pheature\Model\Toggle\EnableByMatchingSegment;
+use Pheature\Model\Toggle\IdentitySegment;
+use Pheature\Model\Toggle\SegmentFactory;
+use Pheature\Model\Toggle\StrategyFactory;
+use Pheature\Model\Toggle\StrictMatchingSegment;
+
+final class PheatureFlagsConfig
+{
+    private array $config;
+
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    public static function createDefault(): self
+    {
+        $defaultConfig = [
+            'driver' => 'inmemory',
+            'api_prefix' => '',
+            'api_enabled' => false,
+            'segment_types' => [
+                [
+                    'type' => IdentitySegment::NAME,
+                    'factory_id' => SegmentFactory::class
+                ],
+                [
+                    'type' => StrictMatchingSegment::NAME,
+                    'factory_id' => SegmentFactory::class
+                ]
+            ],
+            'strategy_types' => [
+                [
+                    'type' => EnableByMatchingSegment::NAME,
+                    'factory_id' => StrategyFactory::class
+                ],
+                [
+                    'type' => EnableByMatchingIdentityId::NAME,
+                    'factory_id' => StrategyFactory::class
+                ]
+            ],
+            'toggles' => [],
+        ];
+
+        return new self($defaultConfig);
+    }
+
+    public function withApiEnabled(bool $enabled): self
+    {
+        $this->config['api_enabled'] = $enabled;
+
+        return $this;
+    }
+
+    public function withApiPrefix(string $prefix): self
+    {
+        $this->config['api_prefix'] = $prefix;
+
+        return $this;
+    }
+
+    public function build(): array
+    {
+        return $this->config;
+    }
+}

--- a/packages/symfony-toggle/test/DependencyInjection/TestContainerFactory.php
+++ b/packages/symfony-toggle/test/DependencyInjection/TestContainerFactory.php
@@ -8,22 +8,33 @@ use Pheature\Community\Symfony\DependencyInjection\PheatureFlagsExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 final class TestContainerFactory
 {
-    public static function create(CompilerPassInterface $compilerPass, string $driver = 'inmemory'): ContainerBuilder
+    public static function create(CompilerPassInterface $compilerPass, ?string $driver = null, array $config = []): ContainerBuilder
     {
         $containerBuilder = new ContainerBuilder();
         $extension = new PheatureFlagsExtension();
         $containerBuilder->registerExtension($extension);
 
-        $phpFileLoader = new YamlFileLoader($containerBuilder, new FileLocator());
+        if (!empty($config)) {
+            $containerBuilder->loadFromExtension('pheature_flags', $config);
+
+            $compilerPass->process($containerBuilder);
+
+            return $containerBuilder;
+        }
+
+        $driver = $driver ?? 'inmemory';
+
+        $yamlFileLoader = new YamlFileLoader($containerBuilder, new FileLocator());
         if ('inmemory' === $driver) {
-            $phpFileLoader->load(realpath(__DIR__ . '/../../config/config.yaml'));
+            $yamlFileLoader->load(realpath(__DIR__ . '/../../config/config.yaml'));
         }
         if ('dbal' === $driver) {
-            $phpFileLoader->load(realpath(__DIR__ . '/../../config/dbal_config.yaml'));
+            $yamlFileLoader->load(realpath(__DIR__ . '/../../config/dbal_config.yaml'));
         }
         $compilerPass->process($containerBuilder);
 

--- a/packages/symfony-toggle/test/DependencyInjection/ToggleAPIPassTest.php
+++ b/packages/symfony-toggle/test/DependencyInjection/ToggleAPIPassTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Test\Community\Symfony\DependencyInjection;
+
+use Pheature\Community\Symfony\DependencyInjection\ToggleAPIPass;
+use Pheature\Test\Community\Symfony\DependencyInjection\Fixtures\PheatureFlagsConfig;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
+
+final class ToggleAPIPassTest extends TestCase
+{
+    public function testItShouldNotLoadApiServicesInContainer(): void
+    {
+        $config = PheatureFlagsConfig::createDefault()
+            ->withApiEnabled(false)
+            ->build();
+
+        $compilerPass = new ToggleAPIPass();
+        $container = TestContainerFactory::create($compilerPass, null, $config);
+
+        $this->expectException(ParameterNotFoundException::class);
+        $container->getParameter('pheature_flags_prefix');
+
+        $expectedLoadedResources = 0;
+        $loadedResources = $container->getResources();
+        self::assertCount($expectedLoadedResources, $loadedResources);
+    }
+
+    public function testItShouldLoadApiServicesInContainer(): void
+    {
+        $expectedPrefix = 'a-prefix';
+
+        $config = PheatureFlagsConfig::createDefault()
+            ->withApiEnabled(true)
+            ->withApiPrefix($expectedPrefix)
+            ->build();
+
+        $compilerPass = new ToggleAPIPass();
+        $container = TestContainerFactory::create($compilerPass, null, $config);
+
+        self::assertSame($expectedPrefix, $container->getParameter('pheature_flags_prefix'));
+
+        $loadedResources = $container->getResources();
+
+        self::assertCount(2, $loadedResources);
+
+        $this->assertSimilarResourceIn('src/Resources/config/toggle_api/services/controller_services.yaml',
+            $loadedResources);
+        $this->assertSimilarResourceIn('src/Resources/config/toggle_api/services/handler_services.yaml',
+            $loadedResources);
+    }
+
+    private function assertSimilarResourceIn(string $similarResource, array $currentResources): void
+    {
+        /** @var FileResource $currentResource */
+        foreach ($currentResources as $currentResource) {
+            if (false !== strpos($currentResource->getResource(), $similarResource)) {
+                return;
+            }
+        }
+
+        $actualResources = json_encode(
+            array_map(static fn(FileResource $fileResource) => $fileResource->getResource(), $currentResources)
+        );
+
+        self::fail(
+            sprintf(
+                'Similar resource "%s" not found in current resources: [%s]',
+                $similarResource,
+                $actualResources
+            )
+        );
+    }
+}

--- a/packages/toggle-crud-psr11-factories/phpunit.xml.dist
+++ b/packages/toggle-crud-psr11-factories/phpunit.xml.dist
@@ -6,7 +6,7 @@
     </include>
   </coverage>
   <testsuites>
-    <testsuite name="Antidot\\Tests">
+    <testsuite name="Pheature\\Test\\Crud\\Psr11">
       <directory>./test</directory>
     </testsuite>
   </testsuites>

--- a/packages/toggle-crud-psr11-factories/src/ToggleConfig.php
+++ b/packages/toggle-crud-psr11-factories/src/ToggleConfig.php
@@ -9,7 +9,7 @@ use Webmozart\Assert\Assert;
 final class ToggleConfig
 {
     private string $driver;
-    private string $prefix;
+    private string $apiPrefix;
     /** @var array<string, mixed> */
     private array $toggles = [];
 
@@ -18,11 +18,11 @@ final class ToggleConfig
      */
     public function __construct(array $config)
     {
-        Assert::keyExists($config, 'prefix');
+        Assert::keyExists($config, 'api_prefix');
         Assert::keyExists($config, 'driver');
-        Assert::string($config['prefix']);
+        Assert::string($config['api_prefix']);
         Assert::string($config['driver']);
-        $this->prefix = $config['prefix'];
+        $this->apiPrefix = $config['api_prefix'];
         $this->driver = $config['driver'];
         if (array_key_exists('toggles', $config)) {
             Assert::isArray($config['toggles']);
@@ -32,9 +32,9 @@ final class ToggleConfig
         }
     }
 
-    public function prefix(): string
+    public function apiPrefix(): string
     {
-        return $this->prefix;
+        return $this->apiPrefix;
     }
 
     public function driver(): string

--- a/packages/toggle-crud-psr11-factories/test/FeatureFinderFactoryTest.php
+++ b/packages/toggle-crud-psr11-factories/test/FeatureFinderFactoryTest.php
@@ -25,7 +25,7 @@ class FeatureFinderFactoryTest extends TestCase
             $this->createMock(SegmentFactory::class),
             $this->createMock(ToggleStrategyFactory::class),
         );
-        $toggleConfig = new ToggleConfig(['prefix' => '', 'driver' => 'some_other']);
+        $toggleConfig = new ToggleConfig(['api_prefix' => '', 'driver' => 'some_other']);
 
         $container->expects(self::exactly(3))
             ->method('get')
@@ -41,7 +41,7 @@ class FeatureFinderFactoryTest extends TestCase
     public function testItShouldCreateADBalFeatureFinderFromInvokable(): void
     {
         $container = $this->createMock(ContainerInterface::class);
-        $toggleConfig = new ToggleConfig(['prefix' => '', 'driver' => 'dbal']);
+        $toggleConfig = new ToggleConfig(['api_prefix' => '', 'driver' => 'dbal']);
         $chainStrategyFactory = new ChainToggleStrategyFactory(
             $this->createMock(SegmentFactory::class),
             $this->createMock(ToggleStrategyFactory::class),
@@ -62,7 +62,7 @@ class FeatureFinderFactoryTest extends TestCase
     public function testItShouldCreateAnInMemoryFeatureFinderFromInvokable(): void
     {
         $container = $this->createMock(ContainerInterface::class);
-        $toggleConfig = new ToggleConfig(['prefix' => '', 'driver' => 'inmemory']);
+        $toggleConfig = new ToggleConfig(['api_prefix' => '', 'driver' => 'inmemory']);
         $chainStrategyFactory = new ChainToggleStrategyFactory(
             $this->createMock(SegmentFactory::class),
             $this->createMock(ToggleStrategyFactory::class),
@@ -81,7 +81,7 @@ class FeatureFinderFactoryTest extends TestCase
 
     public function testItShouldCreateADBalFeatureFinderFromCreate(): void
     {
-        $toggleConfig = new ToggleConfig(['prefix' => '', 'driver' => 'dbal']);
+        $toggleConfig = new ToggleConfig(['api_prefix' => '', 'driver' => 'dbal']);
         $chainStrategyFactory = new ChainToggleStrategyFactory(
             $this->createMock(SegmentFactory::class),
             $this->createMock(ToggleStrategyFactory::class),
@@ -93,7 +93,7 @@ class FeatureFinderFactoryTest extends TestCase
 
     public function testItShouldCreateInMemoryFeatureFinderFromCreate(): void
     {
-        $toggleConfig = new ToggleConfig(['prefix' => '', 'driver' => 'inmemory']);
+        $toggleConfig = new ToggleConfig(['api_prefix' => '', 'driver' => 'inmemory']);
         $chainStrategyFactory = new ChainToggleStrategyFactory(
             $this->createMock(SegmentFactory::class),
             $this->createMock(ToggleStrategyFactory::class),

--- a/packages/toggle-crud-psr11-factories/test/FeatureRepositoryFactoryTest.php
+++ b/packages/toggle-crud-psr11-factories/test/FeatureRepositoryFactoryTest.php
@@ -21,7 +21,7 @@ class FeatureRepositoryFactoryTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $container = $this->createMock(ContainerInterface::class);
-        $toggleConfig = new ToggleConfig(['prefix' => '', 'driver' => 'some_other']);
+        $toggleConfig = new ToggleConfig(['api_prefix' => '', 'driver' => 'some_other']);
 
         $container->expects(self::exactly(2))
             ->method('get')
@@ -36,7 +36,7 @@ class FeatureRepositoryFactoryTest extends TestCase
     public function testItShouldCreateADBalFeatureRepositoryFromInvokable(): void
     {
         $container = $this->createMock(ContainerInterface::class);
-        $toggleConfig = new ToggleConfig(['prefix' => '', 'driver' => 'dbal']);
+        $toggleConfig = new ToggleConfig(['api_prefix' => '', 'driver' => 'dbal']);
         $connection = $this->createMock(Connection::class);
 
         $container->expects(static::exactly(2))
@@ -53,7 +53,7 @@ class FeatureRepositoryFactoryTest extends TestCase
     public function testItShouldCreateAnInMemoryFeatureRepositoryFromInvokable(): void
     {
         $container = $this->createMock(ContainerInterface::class);
-        $toggleConfig = new ToggleConfig(['prefix' => '', 'driver' => 'inmemory']);
+        $toggleConfig = new ToggleConfig(['api_prefix' => '', 'driver' => 'inmemory']);
 
         $container->expects(static::exactly(2))
             ->method('get')
@@ -68,7 +68,7 @@ class FeatureRepositoryFactoryTest extends TestCase
 
     public function testItShouldCreateADBalFeatureRepositoryFromCreate(): void
     {
-        $toggleConfig = new ToggleConfig(['prefix' => '', 'driver' => 'dbal']);
+        $toggleConfig = new ToggleConfig(['api_prefix' => '', 'driver' => 'dbal']);
         $connection = $this->createMock(Connection::class);
         $featureRepository = FeatureRepositoryFactory::create($toggleConfig, $connection);
         self::assertInstanceOf(FeatureRepository::class, $featureRepository);
@@ -76,7 +76,7 @@ class FeatureRepositoryFactoryTest extends TestCase
 
     public function testItShouldCreateInMemoryFeatureRepositoryFromCreate(): void
     {
-        $toggleConfig = new ToggleConfig(['prefix' => '', 'driver' => 'inmemory']);
+        $toggleConfig = new ToggleConfig(['api_prefix' => '', 'driver' => 'inmemory']);
         $connection = null;
         $featureRepository = FeatureRepositoryFactory::create($toggleConfig, $connection);
         self::assertInstanceOf(FeatureRepository::class, $featureRepository);


### PR DESCRIPTION
It closes #178 

Changes applied:
* Create `ToggleApiPass` compiler pass that loads controllers and services only when `api_enabled` config flag is `true`
* Add `routes.yaml` and services related to the API into the `src/Resources/config` folder (See `1`)
* Add new controllers compatible with Symfony (See `2`)

So the user will need to:
* Enable the bundle:
```php
<?php
// config/bundles.php from a Symfony App
return [
    // ...
    Pheature\Community\Symfony\PheatureFlagsBundle::class => ['all' => true],
    // ...
];
```
* Create the config file:
```yaml
# config/packages/pheature_flags.yaml

pheature_flags:
  # ...
  api_enabled: true
  # ...

```
* Import our routes:
```yaml
# config/routes.yaml from a Symfony App
pheature_flags:
  resource: '@PheatureFlagsBundle/Resources/config/toggle_api/routes.yaml'
  prefix: 'feature-flags'   # i.e: GET /feature-flags/features
```

## 1. Add `routes.yaml` and services related to the API into the `src/Resources/config` folder

The path directory for config it was something complicated because checking documentation there're different options:
* https://symfony.com/doc/current/bundles/best_practices.html#directory-structure  -> our current structure except the configuration that is under `src/Resources/config`.
* https://symfony.com/doc/current/bundles.html#bundle-directory-structure -> everything under root path (`Resources/config`)

I finally opted to set all configurations that can be imported by the final Symfony application under `src/Resources/config` because regarding importing routes, it's not possible to import them from the `Extension` or `Bundle` classes. The final user is the responsible for importing the routes under their own prefix:
```yaml
# config/routes.yaml from a Symfony App
pheature_flags:
  resource: '@PheatureFlagsBundle/Resources/config/toggle_api/routes.yaml'
  prefix: 'feature-flags'
```
Also, using this way of importing routes, the routes must be placed under `src/` because the current directory of the `@PheatureFlagsBundle` is just `src/` and it's not allowed the use of relative paths like:
```yaml
# config/routes.yaml from a Symfony App
pheature_flags:
  resource: '@PheatureFlagsBundle/../config/toggle_api/routes.yaml' # <-- ".." is not allowed
  prefix: 'feature-flags'
```
Another clue about that is checking out the following bundles:
* [Symfony MakerBundle](https://github.com/symfony/maker-bundle): Uses `src/` folder structure
* [Symfony FrameworkBundle](https://github.com/symfony/framework-bundle): Uses the folder structure without `src/` folder, everything under the root path (`Resources/config`).

## 2. Add new controllers compatible with Symfony
Checking our current controllers, they're PSR compatible, but due to the fact that Symfony controllers need a specific `Request` and `Response` objects, I've created each Symfony compatible controller under `src/Controller` that is only responsible for converting the Symfony `Request` into a PSR `ServerRequestInterface`, call our PSR compatible controller and then, transform the PSR `ResponseInterface` into a Symfony `Response`.

![image](https://user-images.githubusercontent.com/5933658/118401474-2e060d00-b666-11eb-9f05-118975b00c8d.png)

To do this conversion I installed two packages suggested by the [Symfony documentation](https://symfony.com/doc/current/components/psr7.html):
* `symfony/psr-http-message-bridge`
* `nyholm/psr7`