### PR TITLE
[POC] Inform the user about required packages depending on the chosen driver

### DIFF
--- a/packages/symfony-toggle/composer.json
+++ b/packages/symfony-toggle/composer.json
@@ -15,17 +15,19 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
+        "nyholm/psr7": "^1.4",
+        "pheature/inmemory-toggle": "@dev",
         "pheature/toggle-core": "@dev",
         "pheature/toggle-crud-psr7-api": "@dev",
         "pheature/toggle-crud-psr11-factories": "@dev",
         "pheature/toggle-model": "@dev",
-        "symfony/framework-bundle": "~5.0"
+        "symfony/framework-bundle": "~5.0",
+        "symfony/psr-http-message-bridge": "^2.1"
     },
     "require-dev": {
         "doctrine/dbal": "^3.1",
         "infection/infection": "^0.21.0",
         "pheature/dbal-toggle": "@dev",
-        "pheature/inmemory-toggle": "@dev",
         "pheature/toggle-crud": "@dev",
         "phpro/grumphp": "^1.0",
         "phpstan/phpstan": "^0.12",

--- a/packages/symfony-toggle/composer.json
+++ b/packages/symfony-toggle/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "pheature/toggle-core": "@dev",
+        "pheature/toggle-crud-psr7-api": "@dev",
         "pheature/toggle-crud-psr11-factories": "@dev",
         "pheature/toggle-model": "@dev",
         "symfony/framework-bundle": "~5.0"
@@ -26,7 +27,6 @@
         "pheature/dbal-toggle": "@dev",
         "pheature/inmemory-toggle": "@dev",
         "pheature/toggle-crud": "@dev",
-        "pheature/toggle-crud-psr7-api": "@dev",
         "phpro/grumphp": "^1.0",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": "^8.0 || ^9.0",

--- a/packages/symfony-toggle/composer.json
+++ b/packages/symfony-toggle/composer.json
@@ -16,7 +16,6 @@
     "require": {
         "php": "^7.4|^8.0",
         "nyholm/psr7": "^1.4",
-        "pheature/inmemory-toggle": "@dev",
         "pheature/toggle-core": "@dev",
         "pheature/toggle-crud-psr7-api": "@dev",
         "pheature/toggle-crud-psr11-factories": "@dev",
@@ -25,9 +24,7 @@
         "symfony/psr-http-message-bridge": "^2.1"
     },
     "require-dev": {
-        "doctrine/dbal": "^3.1",
         "infection/infection": "^0.21.0",
-        "pheature/dbal-toggle": "@dev",
         "pheature/toggle-crud": "@dev",
         "phpro/grumphp": "^1.0",
         "phpstan/phpstan": "^0.12",

--- a/packages/symfony-toggle/src/Controller/DeleteFeature.php
+++ b/packages/symfony-toggle/src/Controller/DeleteFeature.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Community\Symfony\Controller;
+
+use Pheature\Community\Symfony\Toggle\Transformer\PsrToSymfonyResponseTransformer;
+use Pheature\Community\Symfony\Toggle\Transformer\SymfonyToPsrRequestTransformer;
+use Pheature\Crud\Psr7\Toggle\DeleteFeature as PsrDeleteFeature;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class DeleteFeature
+{
+    private SymfonyToPsrRequestTransformer $requestTransformer;
+    private PsrToSymfonyResponseTransformer $responseTransformer;
+    private PsrDeleteFeature $deleteFeature;
+
+    public function __construct(
+        SymfonyToPsrRequestTransformer $requestTransformer,
+        PsrToSymfonyResponseTransformer $responseTransformer,
+        PsrDeleteFeature $deleteFeature
+    ) {
+        $this->requestTransformer = $requestTransformer;
+        $this->responseTransformer = $responseTransformer;
+        $this->deleteFeature = $deleteFeature;
+    }
+
+    public function __invoke(Request $symfonyRequest): Response
+    {
+        $psrRequest = $this->requestTransformer->transform($symfonyRequest);
+
+        $psrResponse = $this->deleteFeature->handle($psrRequest);
+
+        return $this->responseTransformer->transform($psrResponse);
+    }
+}

--- a/packages/symfony-toggle/src/Controller/GetFeature.php
+++ b/packages/symfony-toggle/src/Controller/GetFeature.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Community\Symfony\Controller;
+
+use Pheature\Community\Symfony\Toggle\Transformer\PsrToSymfonyResponseTransformer;
+use Pheature\Community\Symfony\Toggle\Transformer\SymfonyToPsrRequestTransformer;
+use Pheature\Crud\Psr7\Toggle\GetFeature as PsrGetFeature;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class GetFeature
+{
+    private SymfonyToPsrRequestTransformer $requestTransformer;
+    private PsrToSymfonyResponseTransformer $responseTransformer;
+    private PsrGetFeature $getFeature;
+
+    public function __construct(
+        SymfonyToPsrRequestTransformer $requestTransformer,
+        PsrToSymfonyResponseTransformer $responseTransformer,
+        PsrGetFeature $getFeature
+    ) {
+        $this->requestTransformer = $requestTransformer;
+        $this->responseTransformer = $responseTransformer;
+        $this->getFeature = $getFeature;
+    }
+
+    public function __invoke(Request $symfonyRequest): Response
+    {
+        $psrRequest = $this->requestTransformer->transform($symfonyRequest);
+
+        $psrResponse = $this->getFeature->handle($psrRequest);
+
+        return $this->responseTransformer->transform($psrResponse);
+    }
+}

--- a/packages/symfony-toggle/src/Controller/GetFeatures.php
+++ b/packages/symfony-toggle/src/Controller/GetFeatures.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Community\Symfony\Controller;
+
+use Pheature\Community\Symfony\Toggle\Transformer\PsrToSymfonyResponseTransformer;
+use Pheature\Community\Symfony\Toggle\Transformer\SymfonyToPsrRequestTransformer;
+use Pheature\Crud\Psr7\Toggle\GetFeatures as PsrGetFeatures;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class GetFeatures
+{
+    private SymfonyToPsrRequestTransformer $requestTransformer;
+    private PsrToSymfonyResponseTransformer $responseTransformer;
+    private PsrGetFeatures $getFeatures;
+
+    public function __construct(
+        SymfonyToPsrRequestTransformer $requestTransformer,
+        PsrToSymfonyResponseTransformer $responseTransformer,
+        PsrGetFeatures $getFeatures
+    ) {
+        $this->requestTransformer = $requestTransformer;
+        $this->responseTransformer = $responseTransformer;
+        $this->getFeatures = $getFeatures;
+    }
+
+    public function __invoke(Request $symfonyRequest): Response
+    {
+        $psrRequest = $this->requestTransformer->transform($symfonyRequest);
+
+        $psrResponse = $this->getFeatures->handle($psrRequest);
+
+        return $this->responseTransformer->transform($psrResponse);
+    }
+}

--- a/packages/symfony-toggle/src/Controller/PatchFeature.php
+++ b/packages/symfony-toggle/src/Controller/PatchFeature.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Community\Symfony\Controller;
+
+use Pheature\Community\Symfony\Toggle\Transformer\PsrToSymfonyResponseTransformer;
+use Pheature\Community\Symfony\Toggle\Transformer\SymfonyToPsrRequestTransformer;
+use Pheature\Crud\Psr7\Toggle\PatchFeature as PsrPatchFeatures;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class PatchFeature
+{
+    private SymfonyToPsrRequestTransformer $requestTransformer;
+    private PsrToSymfonyResponseTransformer $responseTransformer;
+    private PsrPatchFeatures $patchFeature;
+
+    public function __construct(
+        SymfonyToPsrRequestTransformer $requestTransformer,
+        PsrToSymfonyResponseTransformer $responseTransformer,
+        PsrPatchFeatures $patchFeature
+    ) {
+        $this->requestTransformer = $requestTransformer;
+        $this->responseTransformer = $responseTransformer;
+        $this->patchFeature = $patchFeature;
+    }
+
+    public function __invoke(Request $symfonyRequest): Response
+    {
+        $psrRequest = $this->requestTransformer->transform($symfonyRequest);
+
+        $psrResponse = $this->patchFeature->handle($psrRequest);
+
+        return $this->responseTransformer->transform($psrResponse);
+    }
+}

--- a/packages/symfony-toggle/src/Controller/PostFeature.php
+++ b/packages/symfony-toggle/src/Controller/PostFeature.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Community\Symfony\Controller;
+
+use Pheature\Community\Symfony\Toggle\Transformer\PsrToSymfonyResponseTransformer;
+use Pheature\Community\Symfony\Toggle\Transformer\SymfonyToPsrRequestTransformer;
+use Pheature\Crud\Psr7\Toggle\PostFeature as PsrPostFeatures;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class PostFeature
+{
+    private SymfonyToPsrRequestTransformer $requestTransformer;
+    private PsrToSymfonyResponseTransformer $responseTransformer;
+    private PsrPostFeatures $postFeature;
+
+    public function __construct(
+        SymfonyToPsrRequestTransformer $requestTransformer,
+        PsrToSymfonyResponseTransformer $responseTransformer,
+        PsrPostFeatures $postFeature
+    ) {
+        $this->requestTransformer = $requestTransformer;
+        $this->responseTransformer = $responseTransformer;
+        $this->postFeature = $postFeature;
+    }
+
+    public function __invoke(Request $symfonyRequest): Response
+    {
+        $psrRequest = $this->requestTransformer->transform($symfonyRequest);
+
+        $psrResponse = $this->postFeature->handle($psrRequest);
+
+        return $this->responseTransformer->transform($psrResponse);
+    }
+}

--- a/packages/symfony-toggle/src/DependencyInjection/Configuration.php
+++ b/packages/symfony-toggle/src/DependencyInjection/Configuration.php
@@ -26,6 +26,9 @@ final class Configuration implements ConfigurationInterface
             ->scalarNode('prefix')
                 ->defaultValue('')
             ->end()
+            ->booleanNode('api_enabled')
+                ->defaultFalse()
+            ->end()
         ->end();
 
         $this->addStrategyTypes($rootNode);

--- a/packages/symfony-toggle/src/DependencyInjection/FeatureRepositoryFactoryPass.php
+++ b/packages/symfony-toggle/src/DependencyInjection/FeatureRepositoryFactoryPass.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Pheature\Community\Symfony\DependencyInjection;
 
 use Doctrine\DBAL\Connection;
+use InvalidArgumentException;
 use Pheature\Core\Toggle\Write\FeatureRepository;
 use Pheature\Crud\Psr11\Toggle\FeatureRepositoryFactory;
 use Pheature\Crud\Psr11\Toggle\ToggleConfig;
+use Pheature\Dbal\Toggle\Write\DbalFeatureRepository;
+use Pheature\InMemory\Toggle\InMemoryFeatureRepository;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -20,6 +23,8 @@ final class FeatureRepositoryFactoryPass implements CompilerPassInterface
         $pheatureFlagsConfig = $container->getExtensionConfig('pheature_flags');
         $mergedConfig = array_merge(...$pheatureFlagsConfig);
 
+        $this->checkRequiredPackages($mergedConfig);
+
         $repository = $container->register(FeatureRepository::class, FeatureRepository::class)
             ->setAutowired(false)
             ->setLazy(true)
@@ -30,6 +35,22 @@ final class FeatureRepositoryFactoryPass implements CompilerPassInterface
             $repository->addArgument(new Reference(Connection::class));
         } else {
             $repository->addArgument(null);
+        }
+    }
+
+    private function checkRequiredPackages(array $mergedConfig): void
+    {
+        switch ($mergedConfig['driver']) {
+            case 'inmemory':
+                if (!class_exists(InMemoryFeatureRepository::class, true)) {
+                    throw new InvalidArgumentException('Run "composer require pheature/inmemory-toggle" to install InMemory feature storage.');
+                }
+                break;
+            case 'dbal':
+                if (!class_exists(DbalFeatureRepository::class, true)) {
+                    throw new InvalidArgumentException('Run "composer require pheature/dbal-toggle" to install DBAL feature storage.');
+                }
+                break;
         }
     }
 }

--- a/packages/symfony-toggle/src/DependencyInjection/ToggleAPIPass.php
+++ b/packages/symfony-toggle/src/DependencyInjection/ToggleAPIPass.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Community\Symfony\DependencyInjection;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Pheature\Community\Symfony\Toggle\Transformer\NyholmPsrToSymfonyResponseTransformer;
+use Pheature\Community\Symfony\Toggle\Transformer\NyholmSymfonyToPsrRequestTransformer;
+use Pheature\Community\Symfony\Toggle\Transformer\PsrToSymfonyResponseTransformer;
+use Pheature\Community\Symfony\Toggle\Transformer\SymfonyToPsrRequestTransformer;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+final class ToggleAPIPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        /** @var array<array<mixed>> $pheatureFlagsConfig */
+        $pheatureFlagsConfig = $container->getExtensionConfig('pheature_flags');
+        $mergedConfig = array_merge(...$pheatureFlagsConfig);
+
+        if (false === $mergedConfig['api_enabled']) {
+            return;
+        }
+
+        $this->addPsrServices($container);
+
+        $loader = new YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/../Resources/config/toggle_api')
+        );
+        $loader->load('services/controller_services.yaml');
+        $loader->load('services/handler_services.yaml');
+    }
+
+    private function addPsrServices(ContainerBuilder $container): void
+    {
+        $container->register(SymfonyToPsrRequestTransformer::class, NyholmSymfonyToPsrRequestTransformer::class)
+            ->setAutowired(false)
+            ->setLazy(true);
+        $container->register(PsrToSymfonyResponseTransformer::class, NyholmPsrToSymfonyResponseTransformer::class)
+            ->setAutowired(false)
+            ->setLazy(true);
+        $container->register(ResponseFactoryInterface::class, Psr17Factory::class)
+            ->setAutowired(false)
+            ->setLazy(true);
+    }
+}

--- a/packages/symfony-toggle/src/PheatureFlagsBundle.php
+++ b/packages/symfony-toggle/src/PheatureFlagsBundle.php
@@ -7,6 +7,7 @@ namespace Pheature\Community\Symfony;
 use Pheature\Community\Symfony\DependencyInjection\FeatureRepositoryFactoryPass;
 use Pheature\Community\Symfony\DependencyInjection\SegmentFactoryPass;
 use Pheature\Community\Symfony\DependencyInjection\ToggleStrategyFactoryPass;
+use Pheature\Community\Symfony\DependencyInjection\ToggleAPIPass;
 use Pheature\Model\Toggle\EnableByMatchingIdentityId;
 use Pheature\Model\Toggle\EnableByMatchingSegment;
 use Pheature\Model\Toggle\IdentitySegment;
@@ -21,6 +22,7 @@ final class PheatureFlagsBundle extends Bundle
     private const DEFAULT_CONFIG = [
         'driver' => 'inmemory',
         'prefix' => '',
+        'api_enabled' => false,
         'segment_types' => [
             [
                 'type' => IdentitySegment::NAME,
@@ -51,5 +53,6 @@ final class PheatureFlagsBundle extends Bundle
         $container->addCompilerPass(new SegmentFactoryPass());
         $container->addCompilerPass(new ToggleStrategyFactoryPass());
         $container->addCompilerPass(new FeatureRepositoryFactoryPass());
+        $container->addCompilerPass(new ToggleAPIPass());
     }
 }

--- a/packages/symfony-toggle/src/Resources/config/toggle_api/routes.yaml
+++ b/packages/symfony-toggle/src/Resources/config/toggle_api/routes.yaml
@@ -1,0 +1,24 @@
+pheature_flags_toggle_detail:
+  methods: [GET]
+  path: /features/{feature_id}
+  controller: Pheature\Community\Symfony\Controller\GetFeature
+
+pheature_flags_feature_list:
+  methods: [GET]
+  path: /features
+  controller: Pheature\Community\Symfony\Controller\GetFeatures
+
+pheature_flags_feature_create:
+  methods: [POST]
+  path: /features/{feature_id}
+  controller: Pheature\Community\Symfony\Controller\PostFeature
+
+pheature_flags_feature_update:
+  methods: [PATCH]
+  path: /features/{feature_id}
+  controller: Pheature\Community\Symfony\Controller\PatchFeature
+
+pheature_flags_feature_remove:
+  methods: [DELETE]
+  path: /features/{feature_id}
+  controller: Pheature\Community\Symfony\Controller\DeleteFeature

--- a/packages/symfony-toggle/src/Resources/config/toggle_api/services/controller_services.yaml
+++ b/packages/symfony-toggle/src/Resources/config/toggle_api/services/controller_services.yaml
@@ -1,0 +1,81 @@
+services:
+  _defaults:
+    autowire: false
+    autoconfigure: false
+    public: true
+
+  # Symfony Controllers
+  Pheature\Community\Symfony\Controller\GetFeatures:
+    class: Pheature\Community\Symfony\Controller\GetFeatures
+    arguments:
+      - '@Pheature\Community\Symfony\Toggle\Transformer\SymfonyToPsrRequestTransformer'
+      - '@Pheature\Community\Symfony\Toggle\Transformer\PsrToSymfonyResponseTransformer'
+      - '@Pheature\Crud\Psr7\Toggle\GetFeatures'
+    tags: [ 'controller.service_arguments' ]
+
+  Pheature\Community\Symfony\Controller\GetFeature:
+    class: Pheature\Community\Symfony\Controller\GetFeature
+    arguments:
+      - '@Pheature\Community\Symfony\Toggle\Transformer\SymfonyToPsrRequestTransformer'
+      - '@Pheature\Community\Symfony\Toggle\Transformer\PsrToSymfonyResponseTransformer'
+      - '@Pheature\Crud\Psr7\Toggle\GetFeature'
+    tags: [ 'controller.service_arguments' ]
+
+  Pheature\Community\Symfony\Controller\PostFeature:
+    class: Pheature\Community\Symfony\Controller\PostFeature
+    arguments:
+      - '@Pheature\Community\Symfony\Toggle\Transformer\SymfonyToPsrRequestTransformer'
+      - '@Pheature\Community\Symfony\Toggle\Transformer\PsrToSymfonyResponseTransformer'
+      - '@Pheature\Crud\Psr7\Toggle\PostFeature'
+    tags: [ 'controller.service_arguments' ]
+
+  Pheature\Community\Symfony\Controller\PatchFeature:
+    class: Pheature\Community\Symfony\Controller\PatchFeature
+    arguments:
+      - '@Pheature\Community\Symfony\Toggle\Transformer\SymfonyToPsrRequestTransformer'
+      - '@Pheature\Community\Symfony\Toggle\Transformer\PsrToSymfonyResponseTransformer'
+      - '@Pheature\Crud\Psr7\Toggle\PatchFeature'
+    tags: [ 'controller.service_arguments' ]
+
+  Pheature\Community\Symfony\Controller\DeleteFeature:
+    class: Pheature\Community\Symfony\Controller\DeleteFeature
+    arguments:
+      - '@Pheature\Community\Symfony\Toggle\Transformer\SymfonyToPsrRequestTransformer'
+      - '@Pheature\Community\Symfony\Toggle\Transformer\PsrToSymfonyResponseTransformer'
+      - '@Pheature\Crud\Psr7\Toggle\DeleteFeature'
+    tags: [ 'controller.service_arguments' ]
+
+  # PSR Controllers
+  Pheature\Crud\Psr7\Toggle\GetFeatures:
+    class: Pheature\Crud\Psr7\Toggle\GetFeatures
+    arguments:
+      - '@Pheature\Core\Toggle\Read\FeatureFinder'
+      - '@Psr\Http\Message\ResponseFactoryInterface'
+
+  Pheature\Crud\Psr7\Toggle\GetFeature:
+    class: Pheature\Crud\Psr7\Toggle\GetFeature
+    arguments:
+      - '@Pheature\Core\Toggle\Read\FeatureFinder'
+      - '@Psr\Http\Message\ResponseFactoryInterface'
+    tags: [ 'controller.service_arguments' ]
+
+  Pheature\Crud\Psr7\Toggle\PostFeature:
+    class: Pheature\Crud\Psr7\Toggle\PostFeature
+    arguments:
+      - '@Pheature\Crud\Toggle\Handler\CreateFeature'
+      - '@Psr\Http\Message\ResponseFactoryInterface'
+
+  Pheature\Crud\Psr7\Toggle\PatchFeature:
+    class: Pheature\Crud\Psr7\Toggle\PatchFeature
+    arguments:
+      - '@Pheature\Crud\Toggle\Handler\AddStrategy'
+      - '@Pheature\Crud\Toggle\Handler\RemoveStrategy'
+      - '@Pheature\Crud\Toggle\Handler\EnableFeature'
+      - '@Pheature\Crud\Toggle\Handler\DisableFeature'
+      - '@Psr\Http\Message\ResponseFactoryInterface'
+
+  Pheature\Crud\Psr7\Toggle\DeleteFeature:
+    class: Pheature\Crud\Psr7\Toggle\DeleteFeature
+    arguments:
+      - '@Pheature\Crud\Toggle\Handler\RemoveFeature'
+      - '@Psr\Http\Message\ResponseFactoryInterface'

--- a/packages/symfony-toggle/src/Resources/config/toggle_api/services/handler_services.yaml
+++ b/packages/symfony-toggle/src/Resources/config/toggle_api/services/handler_services.yaml
@@ -1,0 +1,34 @@
+services:
+  _defaults:
+    autowire: false
+    autoconfigure: false
+
+  Pheature\Crud\Toggle\Handler\CreateFeature:
+    class: Pheature\Crud\Toggle\Handler\CreateFeature
+    arguments:
+      - '@Pheature\Core\Toggle\Write\FeatureRepository'
+
+  Pheature\Crud\Toggle\Handler\AddStrategy:
+    class: Pheature\Crud\Toggle\Handler\AddStrategy
+    arguments:
+      - '@Pheature\Core\Toggle\Write\FeatureRepository'
+
+  Pheature\Crud\Toggle\Handler\RemoveStrategy:
+    class: Pheature\Crud\Toggle\Handler\RemoveStrategy
+    arguments:
+      - '@Pheature\Core\Toggle\Write\FeatureRepository'
+
+  Pheature\Crud\Toggle\Handler\EnableFeature:
+    class: Pheature\Crud\Toggle\Handler\EnableFeature
+    arguments:
+      - '@Pheature\Core\Toggle\Write\FeatureRepository'
+
+  Pheature\Crud\Toggle\Handler\DisableFeature:
+    class: Pheature\Crud\Toggle\Handler\DisableFeature
+    arguments:
+      - '@Pheature\Core\Toggle\Write\FeatureRepository'
+
+  Pheature\Crud\Toggle\Handler\RemoveFeature:
+    class: Pheature\Crud\Toggle\Handler\RemoveFeature
+    arguments:
+      - '@Pheature\Core\Toggle\Write\FeatureRepository'

--- a/packages/symfony-toggle/src/Toggle/Transformer/NyholmPsrToSymfonyResponseTransformer.php
+++ b/packages/symfony-toggle/src/Toggle/Transformer/NyholmPsrToSymfonyResponseTransformer.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Community\Symfony\Toggle\Transformer;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Component\HttpFoundation\Response;
+
+class NyholmPsrToSymfonyResponseTransformer implements PsrToSymfonyResponseTransformer
+{
+    public function transform(ResponseInterface $psrResponse): Response
+    {
+        $httpFoundationFactory = new HttpFoundationFactory();
+
+        return $httpFoundationFactory->createResponse($psrResponse);
+    }
+}

--- a/packages/symfony-toggle/src/Toggle/Transformer/NyholmSymfonyToPsrRequestTransformer.php
+++ b/packages/symfony-toggle/src/Toggle/Transformer/NyholmSymfonyToPsrRequestTransformer.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Community\Symfony\Toggle\Transformer;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Component\HttpFoundation\Request;
+
+class NyholmSymfonyToPsrRequestTransformer implements SymfonyToPsrRequestTransformer
+{
+    public function transform(Request $symfonyRequest): ServerRequestInterface
+    {
+        $psr17Factory = new Psr17Factory();
+        $psrHttpFactory = new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
+
+        return $psrHttpFactory->createRequest($symfonyRequest);
+    }
+}

--- a/packages/symfony-toggle/src/Toggle/Transformer/PsrToSymfonyResponseTransformer.php
+++ b/packages/symfony-toggle/src/Toggle/Transformer/PsrToSymfonyResponseTransformer.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Community\Symfony\Toggle\Transformer;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+interface PsrToSymfonyResponseTransformer
+{
+    public function transform(ResponseInterface $psrResponse): Response;
+}

--- a/packages/symfony-toggle/src/Toggle/Transformer/SymfonyToPsrRequestTransformer.php
+++ b/packages/symfony-toggle/src/Toggle/Transformer/SymfonyToPsrRequestTransformer.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Community\Symfony\Toggle\Transformer;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+interface SymfonyToPsrRequestTransformer
+{
+    public function transform(Request $symfonyRequest): ServerRequestInterface;
+}

--- a/packages/symfony-toggle/test/DependencyInjection/ConfigurationTest.php
+++ b/packages/symfony-toggle/test/DependencyInjection/ConfigurationTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 
-class ConfigurationTest extends TestCase
+final class ConfigurationTest extends TestCase
 {
     /** @dataProvider validConfigurations */
     public function testItShouldReturnAConfiguration(array $actualConfig, array $expectedConfig): void

--- a/packages/symfony-toggle/test/DependencyInjection/ConfigurationTest.php
+++ b/packages/symfony-toggle/test/DependencyInjection/ConfigurationTest.php
@@ -38,6 +38,7 @@ class ConfigurationTest extends TestCase
             'user config' => [],
             'expected config' => [
                 'prefix' => '',
+                'api_enabled' => false,
                 'strategy_types' => [],
                 'segment_types' => [],
                 'toggles' => [],
@@ -52,6 +53,7 @@ class ConfigurationTest extends TestCase
             ],
             'expected config' => [
                 'prefix' => 'myapp',
+                'api_enabled' => false,
                 'strategy_types' => [],
                 'segment_types' => [],
                 'toggles' => [],
@@ -66,6 +68,7 @@ class ConfigurationTest extends TestCase
             ],
             'expected config' => [
                 'prefix' => '',
+                'api_enabled' => false,
                 'driver' => 'dbal',
                 'strategy_types' => [],
                 'segment_types' => [],
@@ -86,6 +89,7 @@ class ConfigurationTest extends TestCase
             ],
             'expected config' => [
                 'prefix' => '',
+                'api_enabled' => false,
                 'strategy_types' => [
                     [
                         'type' => 'my_strategy_type',
@@ -110,6 +114,7 @@ class ConfigurationTest extends TestCase
             ],
             'expected config' => [
                 'prefix' => '',
+                'api_enabled' => false,
                 'strategy_types' => [],
                 'segment_types' => [
                     [
@@ -149,6 +154,7 @@ class ConfigurationTest extends TestCase
             ],
             'expected config' => [
                 'prefix' => '',
+                'api_enabled' => false,
                 'strategy_types' => [],
                 'segment_types' => [],
                 'toggles' => [

--- a/packages/toggle-crud-psr11-factories/composer.json
+++ b/packages/toggle-crud-psr11-factories/composer.json
@@ -21,8 +21,6 @@
     },
     "require-dev": {
         "infection/infection": "^0.21.0",
-        "pheature/dbal-toggle": "@dev",
-        "pheature/inmemory-toggle": "@dev",
         "phpro/grumphp": "^1.0",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": "^8.0 || ^9.0",

--- a/packages/toggle-crud-psr11-factories/src/FeatureFinderFactory.php
+++ b/packages/toggle-crud-psr11-factories/src/FeatureFinderFactory.php
@@ -38,6 +38,10 @@ final class FeatureFinderFactory
         $driver = $config->driver();
 
         if ('inmemory' === $driver) {
+            if (!class_exists(InMemoryFeatureFinder::class, true)) {
+                throw new InvalidArgumentException('Run "composer require pheature/inmemory-toggle" to install InMemory feature storage.');
+            }
+
             return new InMemoryFeatureFinder(
                 new InMemoryConfig($config->toggles()),
                 new InMemoryFeatureFactory(
@@ -47,6 +51,10 @@ final class FeatureFinderFactory
         }
 
         if ('dbal' === $driver) {
+            if (!class_exists(DbalFeatureFinder::class, true)) {
+                throw new InvalidArgumentException('Run "composer require pheature/dbal-toggle" to install DBAL feature storage.');
+            }
+
             /** @var Connection $connection */
             return new DbalFeatureFinder($connection, new DbalFeatureFactory());
         }

--- a/packages/toggle-crud-psr11-factories/src/FeatureRepositoryFactory.php
+++ b/packages/toggle-crud-psr11-factories/src/FeatureRepositoryFactory.php
@@ -28,10 +28,16 @@ final class FeatureRepositoryFactory
         $driver = $config->driver();
 
         if ('inmemory' === $driver) {
+            if (!class_exists(InMemoryFeatureRepository::class, true)) {
+                throw new InvalidArgumentException('Run "composer require pheature/inmemory-toggle" to install InMemory feature storage.');
+            }
             return new InMemoryFeatureRepository();
         }
 
         if ('dbal' === $driver) {
+            if (!class_exists(DbalFeatureRepository::class, true)) {
+                throw new InvalidArgumentException('Run "composer require pheature/dbal-toggle" to install DBAL feature storage.');
+            }
             /** @var Connection $connection */
             return new DbalFeatureRepository($connection);
         }


### PR DESCRIPTION
It's only a proof of concept with the current implementation of each package.

The idea is to inform the user about the required packages they need to install based on the chosen driver in this case.

So, if the user chooses `dbal` in the configuration and they've not installed our `pheature/dbal-toggle`, the following error is shown:
```
Run "composer require pheature/dbal-toggle" to install DBAL feature storage.
```

And the same for `inmemory`:
```
Run "composer require pheature/inmemory-toggle" to install InMemory feature storage.
```

What do you think about this message?

The problem of this implementation is that we have this check in multiple pieces and maybe we could find a way to centralise this check in a single place per type, one for `FeatureFinder` and another one for `FeatureRepository`.

The benefit of this message is that we can remove the dependencies of the `pheature/dbal-toggle` and `pheature/inmemory-toggle` from `symfony-toggle` and `toggle-crud-psr11-factories`.