### PR TITLE
[#266][symfony-toggle] fix api test in symfony toggle

### DIFF
--- a/packages/symfony-toggle/test/DependencyInjection/ToggleAPIPassTest.php
+++ b/packages/symfony-toggle/test/DependencyInjection/ToggleAPIPassTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Pheature\Test\Community\Symfony\DependencyInjection;
 
 use Pheature\Community\Symfony\DependencyInjection\ToggleAPIPass;
-use Pheature\Test\Crud\Psr11\Toggle\Fixtures\PheatureFlagsConfig;
+use Pheature\Test\Community\Symfony\Fixtures\PheatureFlagsConfig;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;

--- a/packages/symfony-toggle/test/Fixtures/PheatureFlagsConfig.php
+++ b/packages/symfony-toggle/test/Fixtures/PheatureFlagsConfig.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheature\Test\Community\Symfony\Fixtures;
+
+use Pheature\Model\Toggle\EnableByMatchingIdentityId;
+use Pheature\Model\Toggle\EnableByMatchingSegment;
+use Pheature\Model\Toggle\IdentitySegment;
+use Pheature\Model\Toggle\SegmentFactory;
+use Pheature\Model\Toggle\StrategyFactory;
+use Pheature\Model\Toggle\StrictMatchingSegment;
+
+final class PheatureFlagsConfig
+{
+    private array $config;
+
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    public static function createDefault(): self
+    {
+        $defaultConfig = [
+            'driver' => 'inmemory',
+            'api_prefix' => '',
+            'api_enabled' => false,
+            'segment_types' => [
+                [
+                    'type' => IdentitySegment::NAME,
+                    'factory_id' => SegmentFactory::class
+                ],
+                [
+                    'type' => StrictMatchingSegment::NAME,
+                    'factory_id' => SegmentFactory::class
+                ]
+            ],
+            'strategy_types' => [
+                [
+                    'type' => EnableByMatchingSegment::NAME,
+                    'factory_id' => StrategyFactory::class
+                ],
+                [
+                    'type' => EnableByMatchingIdentityId::NAME,
+                    'factory_id' => StrategyFactory::class
+                ]
+            ],
+            'toggles' => [],
+        ];
+
+        return new self($defaultConfig);
+    }
+
+    public function withApiEnabled(bool $enabled): self
+    {
+        $this->config['api_enabled'] = $enabled;
+
+        return $this;
+    }
+
+    public function withApiPrefix(string $prefix): self
+    {
+        $this->config['api_prefix'] = $prefix;
+
+        return $this;
+    }
+
+    public function build(): array
+    {
+        return $this->config;
+    }
+}


### PR DESCRIPTION
Closes #266. @xserrat  we have to check this because we are using a test class from another package, which is not autoloaded by default. I simply duplicate the test class and add it to the Symfony package test namespace.