### PR TITLE
[#223] set development versions on composer to allow dealing bc-breaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "doctrine/annotations": ">=1.2.7",
         "illuminate/support": "^8.37",
         "nyholm/psr7": "^1.4",
-        "pheature/php-sdk": "@dev",
         "php": "^7.4|^8.0",
         "psr/container": "^1.0.0|^2.0.0",
         "psr/http-factory": "^1.0",
@@ -76,6 +75,12 @@
         }
     },
     "scripts": {
+        "precommit-check": [
+            "@cs-check",
+            "@test",
+            "@inspect",
+            "@psalm"
+        ],
         "check-all": [
             "@cs-check",
             "@test",

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,10 +1,10 @@
 grumphp:
-    git_hook_variables:
-        EXEC_GRUMPHP_COMMAND: 'docker run -e "TERM=xterm-256color" --tty=true --rm -v $PWD:/code:cached pheature/pheature-php-dev:latest'
+#    git_hook_variables:
+#        EXEC_GRUMPHP_COMMAND: 'docker run -e "TERM=xterm-256color" --tty=true --rm -v $PWD:/code:cached pheature/pheature-php-dev:latest'
     hooks_dir: .
     hooks_preset: local
     tasks:
         composer_script:
-            script: check-all
+            script: precommit-check
             triggered_by: [php, phtml]
             working_directory: ~

--- a/packages/dbal-toggle/composer.json
+++ b/packages/dbal-toggle/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "php": "^7.4|^8.0",
         "doctrine/dbal": ">=2.6 || ^3.0.0",
-        "pheature/toggle-core": "^0.1.1",
-        "pheature/toggle-model": "^0.1.1"
+        "pheature/toggle-core": "1.0.x-dev",
+        "pheature/toggle-model": "1.0.x-dev"
     },
     "require-dev": {
         "icanhazstring/composer-unused": "^0.7.5",

--- a/packages/inmemory-toggle/composer.json
+++ b/packages/inmemory-toggle/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "pheature/toggle-core": "^0.1.1",
-        "pheature/toggle-model": "^0.1.1",
+        "pheature/toggle-core": "1.0.x-dev",
+        "pheature/toggle-model": "1.0.x-dev",
         "webmozart/assert": "^1.10"
     },
     "require-dev": {

--- a/packages/laravel-toggle/composer.json
+++ b/packages/laravel-toggle/composer.json
@@ -20,14 +20,14 @@
         "illuminate/support": "^8.37",
         "laravel/laravel": ">=8.5.17",
         "nyholm/psr7": "^1.4",
-        "pheature/dbal-toggle": "^0.1.1",
-        "pheature/inmemory-toggle": "^0.1.1",
-        "pheature/php-sdk": "^0.1.1",
-        "pheature/toggle-core": "^0.1.1",
-        "pheature/toggle-crud": "^0.1.1",
-        "pheature/toggle-crud-psr7-api": "^0.1.1",
-        "pheature/toggle-crud-psr11-factories": "^0.1.1",
-        "pheature/toggle-model": "^0.1.1"
+        "pheature/toggle-core": "1.0.x-dev",
+        "pheature/toggle-model": "1.0.x-dev",
+        "pheature/dbal-toggle": "1.0.x-dev",
+        "pheature/inmemory-toggle": "1.0.x-dev",
+        "pheature/php-sdk": "1.0.x-dev",
+        "pheature/toggle-crud": "1.0.x-dev",
+        "pheature/toggle-crud-psr7-api": "1.0.x-dev",
+        "pheature/toggle-crud-psr11-factories": "1.0.x-dev"
     },
     "require-dev": {
         "icanhazstring/composer-unused": "^0.7.5",

--- a/packages/php-sdk/composer.json
+++ b/packages/php-sdk/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "pheature/toggle-core": "^0.1.1",
+        "pheature/toggle-core": "1.0.x-dev",
         "psr/container": "^1.0.0|^2.0.0"
     },
     "require-dev": {

--- a/packages/toggle-crud-psr11-factories/composer.json
+++ b/packages/toggle-crud-psr11-factories/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "pheature/toggle-core": "^0.1.1",
-        "pheature/toggle-model": "^0.1.1"
+        "pheature/toggle-core": "1.0.x-dev",
+        "pheature/toggle-model": "1.0.x-dev"
     },
     "require-dev": {
         "icanhazstring/composer-unused": "^0.7.5",

--- a/packages/toggle-crud-psr7-api/composer.json
+++ b/packages/toggle-crud-psr7-api/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "pheature/toggle-core": "^0.1.1",
-        "pheature/toggle-crud": "^0.1.1",
-        "pheature/toggle-model": "^0.1.1",
+        "pheature/toggle-core": "1.0.x-dev",
+        "pheature/toggle-model": "1.0.x-dev",
+        "pheature/toggle-crud": "1.0.x-dev",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",

--- a/packages/toggle-crud/composer.json
+++ b/packages/toggle-crud/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "pheature/toggle-core": "^0.1.1"
+        "pheature/toggle-core": "1.0.x-dev"
     },
     "require-dev": {
         "icanhazstring/composer-unused": "^0.7.5",

--- a/packages/toggle-model/composer.json
+++ b/packages/toggle-model/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "pheature/toggle-core": "^0.1.1"
+        "pheature/toggle-core": "1.0.x-dev"
     },
     "require-dev": {
         "icanhazstring/composer-unused": "^0.7.5",

--- a/packages/toggle-model/src/StrategyFactoryFactory.php
+++ b/packages/toggle-model/src/StrategyFactoryFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Pheature\Model\Toggle;
 
 use Pheature\Core\Toggle\Read\ToggleStrategyFactory;
-use Pheature\Model\Toggle\StrategyFactory;
 use Psr\Container\ContainerInterface;
 
 final class StrategyFactoryFactory


### PR DESCRIPTION
We added some bc breaks that we have to deal with, which is not a problem because releasing a minor will stabilize them, but to allow passing pipelines we need to use the latest dev versions instead of the tagged ones.