### PR TITLE
[#223] add segment types getter in toggle config

### DIFF
--- a/packages/toggle-crud-psr11-factories/src/ToggleConfig.php
+++ b/packages/toggle-crud-psr11-factories/src/ToggleConfig.php
@@ -20,6 +20,8 @@ final class ToggleConfig
     private string $apiPrefix;
     /** @var array<array<string, string>> */
     private array $strategyTypes;
+    /** @var array<array<string, string>> */
+    private array $segmentTypes;
     /** @var array<string, mixed> */
     private array $toggles;
 
@@ -38,6 +40,7 @@ final class ToggleConfig
         $this->apiPrefix = $config['api_prefix'];
         $this->driver = (string) $config['driver'];
         $this->strategyTypes = [];
+        $this->segmentTypes = [];
         $this->toggles = [];
 
         if (array_key_exists('strategy_types', $config)) {
@@ -45,6 +48,13 @@ final class ToggleConfig
             /** @var array<array<string, string>> $strategyTypes */
             $strategyTypes = $config['strategy_types'];
             $this->strategyTypes = $strategyTypes;
+        }
+
+        if (array_key_exists('segment_types', $config)) {
+            Assert::isArray($config['segment_types']);
+            /** @var array<array<string, string>> $segmentTypes */
+            $segmentTypes = $config['segment_types'];
+            $this->segmentTypes = $segmentTypes;
         }
 
         if (array_key_exists('toggles', $config)) {
@@ -87,6 +97,14 @@ final class ToggleConfig
     public function strategyTypes(): array
     {
         return $this->strategyTypes;
+    }
+
+    /**
+     * @return array<array<string, string>>
+     */
+    public function segmentTypes(): array
+    {
+        return $this->segmentTypes;
     }
 
     /**

--- a/packages/toggle-crud-psr11-factories/test/ToggleConfigFactoryTest.php
+++ b/packages/toggle-crud-psr11-factories/test/ToggleConfigFactoryTest.php
@@ -15,8 +15,6 @@ use Pheature\Model\Toggle\StrategyFactory;
 use Pheature\Model\Toggle\StrictMatchingSegment;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Psr\Container\NotFoundExceptionInterface;
-use UnexpectedValueException;
 
 final class ToggleConfigFactoryTest extends TestCase
 {


### PR DESCRIPTION
As well as we have strategy types getter we also need segment types getter inside PSR-11 package's ToggleConfig class