### PR TITLE
[#307][monorepo-submodule] Submodules are cloned in http mode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,36 +1,36 @@
 [submodule "packages/toggle-core"]
 	path = packages/toggle-core
-	url = https://github.com/feature-flags/toggle-core.git
+	url = ../toggle-core.git
 [submodule "packages/toggle-model"]
 	path = packages/toggle-model
-	url = https://github.com/pheature-flags/toggle-model.git
+	url = ../toggle-model.git
 [submodule "packages/toggle-crud"]
 	path = packages/toggle-crud
-	url = https://github.com/pheature-flags/toggle-crud.git
+	url = ../toggle-crud.git
 [submodule "packages/inmemory-toggle"]
 	path = packages/inmemory-toggle
-	url = https://github.com/pheature-flags/inmemory-toggle.git
+	url = ../inmemory-toggle.git
 [submodule "packages/dbal-toggle"]
 	path = packages/dbal-toggle
-	url = https://github.com/pheature-flags/dbal-toggle.git
+	url = ../dbal-toggle.git
 [submodule "packages/php-sdk"]
 	path = packages/php-sdk
-	url = https://github.com/pheature-flags/php-sdk.git
+	url = ../php-sdk.git
 [submodule "packages/toggle-crud-psr11-factories"]
 	path = packages/toggle-crud-psr11-factories
-	url = https://github.com/pheature-flags/toggle-crud-psr11-factories.git
+	url = ../toggle-crud-psr11-factories.git
 [submodule "packages/toggle-crud-psr7-api"]
 	path = packages/toggle-crud-psr7-api
-	url = https://github.com/pheature-flags/toggle-crud-psr7-api.git
+	url = ../toggle-crud-psr7-api.git
 [submodule "packages/laravel-toggle"]
 	path = packages/laravel-toggle
-	url = https://github.com/pheature-flags/laravel-toggle.git
+	url = ../laravel-toggle.git
 [submodule "packages/symfony-toggle"]
 	path = packages/symfony-toggle
-	url = https://github.com/pheature-flags/symfony-toggle.git
+	url = ../symfony-toggle.git
 [submodule "packages/mezzio-toggle"]
 	path = packages/mezzio-toggle
-	url = https://github.com/pheature-flags/mezzio-toggle.git
+	url = ../mezzio-toggle.git
 [submodule "prototypes/pheature-driven-laravel"]
 	path = prototypes/pheature-driven-laravel
 	url = https://github.com/kpicaza/pheature-driven-laravel.git


### PR DESCRIPTION
Closes #307 

**Describe the Pull Request**
Using the absolute url for each submodule, all package clones are done using https mode. In order to use the same mode as in the monorepo, we have to define the url of each submodule as relative.

Now in my `.git/config`:

![image](https://user-images.githubusercontent.com/5933658/135753000-26c2db82-2b9d-4ebb-b9d5-1cbda5a95a9d.png)


- [x] I read contribution guidelines
- [x] Pull request introduces a BC-Break
- [x] Pull request is covered by tests
- [x] Pull request is properly documented in docs
